### PR TITLE
tolerate (but remove) newlines in gecos

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -543,6 +543,8 @@ class PasswdUpdateGetter(UpdateGetter):
     else:
       raise ValueError('Neither gecos nor cn found')
 
+    pw.gecos = pw.gecos.replace('\n','')
+
     pw.name = obj['uid'][0]
     if 'loginShell' in obj:
       pw.shell = obj['loginShell'][0]


### PR DESCRIPTION
This is a point solution to an issue with an installation to which I'm witness.  GV is normally employed here and can clean up a wacky looking gecos field that would otherwise generate a corrupt /etc/passwd file.
