### PR TITLE
Allow for custom uid attribute in passwd ldap source

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -521,12 +521,12 @@ class PasswdUpdateGetter(UpdateGetter):
   """Get passwd updates."""
 
   def __init__(self, conf):
-    self.conf = conf
     super(PasswdUpdateGetter, self).__init__()
+    self.conf = conf
     self.attrs = ['uid', 'uidNumber', 'gidNumber', 'gecos', 'cn',
                   'homeDirectory', 'loginShell', 'fullName']
     if 'uidattr' in self.conf:
-      self.attrs.append(self.conf[uidattr])
+      self.attrs.append(self.conf['uidattr'])
     if 'uidregex' in self.conf:
       self.uidregex = re.compile(self.conf['uidregex'])
     self.essential_fields = ['uid', 'uidNumber', 'gidNumber', 'homeDirectory']
@@ -552,7 +552,7 @@ class PasswdUpdateGetter(UpdateGetter):
     pw.gecos = pw.gecos.replace('\n','')
 
     if 'uidattr' in self.conf:
-      pw.name = obj[self.conf[uidattr]][0]
+      pw.name = obj[self.conf['uidattr']][0]
     else:
       pw.name = obj['uid'][0]
 
@@ -579,6 +579,7 @@ class GroupUpdateGetter(UpdateGetter):
 
   def __init__(self,conf):
     super(GroupUpdateGetter, self).__init__()
+    self.conf = conf
     if 'rfc2307bis' in conf and conf['rfc2307bis']:
       self.attrs = ['cn', 'gidNumber', 'member']
     else:

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -580,7 +580,7 @@ class GroupUpdateGetter(UpdateGetter):
   def __init__(self,conf):
     super(GroupUpdateGetter, self).__init__()
     self.conf = conf
-    if 'rfc2307bis' in conf and conf['rfc2307bis']:
+    if conf.get('rfc2307bis'):
       self.attrs = ['cn', 'gidNumber', 'member']
     else:
       self.attrs = ['cn', 'gidNumber', 'memberUid']

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -422,6 +422,9 @@ class LdapSource(source.Source):
 
 class UpdateGetter(object):
   """Base class that gets updates from LDAP."""
+  def __init__(self, conf):
+    super(UpdateGetter, self).__init__()
+    self.conf = conf
 
   def FromLdapToTimestamp(self, ldap_ts_string):
     """Transforms a LDAP timestamp into the nss_cache internal timestamp.
@@ -521,8 +524,7 @@ class PasswdUpdateGetter(UpdateGetter):
   """Get passwd updates."""
 
   def __init__(self, conf):
-    super(PasswdUpdateGetter, self).__init__()
-    self.conf = conf
+    super(PasswdUpdateGetter, self).__init__(conf)
     self.attrs = ['uid', 'uidNumber', 'gidNumber', 'gecos', 'cn',
                   'homeDirectory', 'loginShell', 'fullName']
     if 'uidattr' in self.conf:
@@ -578,8 +580,7 @@ class GroupUpdateGetter(UpdateGetter):
   """Get group updates."""
 
   def __init__(self,conf):
-    super(GroupUpdateGetter, self).__init__()
-    self.conf = conf
+    super(GroupUpdateGetter, self).__init__(conf)
     if conf.get('rfc2307bis'):
       self.attrs = ['cn', 'gidNumber', 'member']
     else:
@@ -625,7 +626,7 @@ class ShadowUpdateGetter(UpdateGetter):
   """Get Shadow updates from the LDAP Source."""
 
   def __init__(self):
-    super(ShadowUpdateGetter, self).__init__()
+    super(ShadowUpdateGetter, self).__init__(conf)
     self.attrs = ['uid', 'shadowLastChange', 'shadowMin',
                   'shadowMax', 'shadowWarning', 'shadowInactive',
                   'shadowExpire', 'shadowFlag', 'userPassword']

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -73,9 +73,20 @@ ldap_filter = (objectclass=posixAccount)
 # Should we issue STARTTLS?
 #ldap_tls_starttls = 1
 
-
 # Default uid-like attribute
 #ldap_uidattr = 'uid'
+
+# A Python regex to extract uid components from the uid-like attribute.
+# All matching groups are concatenated without spaces.
+# For example:  '(.*)@example.com' would return a uid to the left of
+# the @example.com domain.  Default is no regex.
+#ldap_uidregex = ''
+
+# A Python regex to extract group member components from the member or
+# memberOf attributes.  All matching groups are concatenated without spaces.
+# For example:  '(.*)@example.com' would return a member without the
+# the @example.com domain.  Default is no regex.
+#ldap_groupregex = ''
 
 # Debug logging
 #ldap_debug = 3

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -73,6 +73,10 @@ ldap_filter = (objectclass=posixAccount)
 # Should we issue STARTTLS?
 #ldap_tls_starttls = 1
 
+
+# Default uid-like attribute
+#ldap_uidattr = 'uid'
+
 # Debug logging
 #ldap_debug = 3
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -155,6 +155,10 @@ Filename containing trusted CA certificates.  Defaults to
 .I /usr/share/ssl/cert.pem
 
 .TP
+.B ldap_uidattr
+The uid-like attribute in your directory.  Defaults to uid.
+
+.TP
 .B ldap_debug
 Sets the debug level for the underlying C library.  Defaults to no logging.
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -159,6 +159,20 @@ Filename containing trusted CA certificates.  Defaults to
 The uid-like attribute in your directory.  Defaults to uid.
 
 .TP
+.B ldap_uidregex
+A Python regex to extract uid components from the uid-like attribute.
+All matching groups are concatenated without spaces.
+For example:  '(.*)@example.com' would return a uid to the left of
+the @example.com domain.  Default is no regex.
+
+.TP
+.B ldap_groupregex
+A Python regex to extract group member components from the member or
+memberOf attributes.  All matching groups are concatenated without spaces.
+For example:  '(.*)@example.com' would return a member without the
+the @example.com domain.  Default is no regex.
+
+.TP
 .B ldap_debug
 Sets the debug level for the underlying C library.  Defaults to no logging.
 


### PR DESCRIPTION
We store our POSIX usernames in a different field than uid.

This is a simple patch just to gauge how this should be done, I'm open to feedback on how you want it handled.