### PR TITLE
Set pycurl.TIMEOUT so that an update does not hang waiting indefinitely

### DIFF
--- a/nss_cache/sources/httpsource.py
+++ b/nss_cache/sources/httpsource.py
@@ -70,6 +70,8 @@ class HttpFilesSource(source.Source):
       conn = pycurl.Curl()
       conn.setopt(pycurl.NOPROGRESS, 1)
       conn.setopt(pycurl.NOSIGNAL, 1)
+      # Don't hang on to connections from broken servers indefinitely.
+      conn.setopt(pycurl.TIMEOUT, 60)
       conn.setopt(pycurl.USERAGENT, 'nsscache')
       if self.conf['http_proxy']:
         conn.setopt(pycurl.PROXY, self.conf['http_proxy'])


### PR DESCRIPTION
Don't hang forever waiting for a broken HTTP server. When the timeout hits, it should trigger a retry, at which point the server will be able to service the request.
