### PR TITLE
Add new source for Consul

### DIFF
--- a/nss_cache/sources/consulsource.py
+++ b/nss_cache/sources/consulsource.py
@@ -1,0 +1,165 @@
+"""An implementation of a consul data source for nsscache."""
+
+__author__ = 'hexedpackets@gmail.com (William Huba)'
+
+import base64
+import collections
+import logging
+import json
+
+from nss_cache.maps import group
+from nss_cache.maps import passwd
+from nss_cache.sources import httpsource
+
+
+def RegisterImplementation(registration_callback):
+  registration_callback(ConsulFilesSource)
+
+
+class ConsulFilesSource(httpsource.HttpFilesSource):
+  """Source for data fetched via Consul."""
+
+  # Consul defaults
+  DATACENTER = 'dc1'
+  TOKEN = ''
+
+  # for registration
+  name = 'consul'
+
+  def _SetDefaults(self, configuration):
+    """Set defaults if necessary."""
+
+    super(ConsulFilesSource, self)._SetDefaults(configuration)
+
+    if 'token' not in configuration:
+      configuration['token'] = self.TOKEN
+    if 'datacenter' not in configuration:
+      configuration['datacenter'] = self.DATACENTER
+
+    for url in ['passwd_url', 'group_url']:
+      configuration[url] = '{}?recurse&token={}&dc={}'.format(
+          configuration[url], configuration['token'], configuration['datacenter'])
+
+  def GetPasswdMap(self, since=None):
+    """Return the passwd map from this source.
+
+    Args:
+      since: Get data only changed since this timestamp (inclusive) or None
+      for all data.
+
+    Returns:
+      instance of passwd.PasswdMap
+    """
+    return PasswdUpdateGetter().GetUpdates(self, self.conf['passwd_url'], since)
+
+  def GetGroupMap(self, since=None):
+    """Return the group map from this source.
+
+    Args:
+      since: Get data only changed since this timestamp (inclusive) or None
+      for all data.
+
+    Returns:
+      instance of group.GroupMap
+    """
+    return GroupUpdateGetter().GetUpdates(self, self.conf['group_url'], since)
+
+
+class PasswdUpdateGetter(httpsource.UpdateGetter):
+  """Get passwd updates."""
+
+  def GetParser(self):
+    """Returns a MapParser to parse FilesPasswd cache."""
+    return ConsulPasswdMapParser()
+
+  def CreateMap(self):
+    """Returns a new PasswdMap instance to have PasswdMapEntries added to it."""
+    return passwd.PasswdMap()
+
+
+class GroupUpdateGetter(httpsource.UpdateGetter):
+  """Get group updates."""
+
+  def GetParser(self):
+    """Returns a MapParser to parse FilesGroup cache."""
+    return ConsulGroupMapParser()
+
+  def CreateMap(self):
+    """Returns a new GroupMap instance to have GroupMapEntries added to it."""
+    return group.GroupMap()
+
+
+class ConsulMapParser(object):
+  """A base class for parsing nss_files module cache."""
+
+  def __init__(self):
+    self.log = logging.getLogger(self.__class__.__name__)
+
+  def GetMap(self, cache_info, data):
+    """Returns a map from a cache.
+
+    Args:
+      cache_info: file like object containing the cache.
+      data: a Map to populate.
+    Returns:
+      A child of Map containing the cache data.
+    """
+
+    entries = collections.defaultdict(dict)
+    for line in json.loads(cache_info.read()):
+      key = line.get('Key', '').split('/')
+      value = line.get('Value', '')
+      if not value or not key:
+        continue
+      value = base64.b64decode(value)
+      name = str(key[-2])
+      entry_piece = key[-1]
+      entries[name][entry_piece] = value
+
+    for name, entry in entries.iteritems():
+      map_entry = self._ReadEntry(name, entry)
+      if map_entry is None:
+        self.log.warn('Could not create entry from line %r in cache, skipping',
+                      entry)
+        continue
+      if not data.Add(map_entry):
+        self.log.warn('Could not add entry %r read from line %r in cache',
+                      map_entry, entry)
+    return data
+
+
+class ConsulPasswdMapParser(ConsulMapParser):
+  """Class for parsing nss_files module passwd cache."""
+
+  def _ReadEntry(self, name, entry):
+    """Return a PasswdMapEntry from a record in the target cache."""
+
+    map_entry = passwd.PasswdMapEntry()
+    # maps expect strict typing, so convert to int as appropriate.
+    map_entry.name = name
+    map_entry.passwd = entry.get('passwd', 'x')
+    map_entry.uid = int(entry['uid'])
+    map_entry.gid = int(entry['gid'])
+    map_entry.gecos = entry.get('comment', '')
+    map_entry.dir = entry.get('home', '/home/{}'.format(name))
+    map_entry.shell = entry.get('shell', '/bin/bash')
+    return map_entry
+
+
+class ConsulGroupMapParser(ConsulMapParser):
+  """Class for parsing a nss_files module group cache."""
+
+  def _ReadEntry(self, name, entry):
+    """Return a GroupMapEntry from a record in the target cache."""
+
+    map_entry = group.GroupMapEntry()
+    # map entries expect strict typing, so convert as appropriate
+    map_entry.name = name
+    map_entry.passwd = entry.get('passwd', 'x')
+    map_entry.gid = int(entry['gid'])
+    try:
+      members = entry.get('members', '').split('\n')
+    except (ValueError, TypeError):
+      members = ['']
+    map_entry.members = members
+    return map_entry

--- a/nss_cache/sources/consulsource_test.py
+++ b/nss_cache/sources/consulsource_test.py
@@ -1,0 +1,115 @@
+"""An implementation of a mock consul data source for nsscache."""
+
+__author__ = 'hexedpackets@gmail.com (William Huba)'
+
+import StringIO
+import unittest
+
+from nss_cache.maps import group
+from nss_cache.maps import passwd
+from nss_cache.sources import consulsource
+
+
+class TestConsulSource(unittest.TestCase):
+
+  def setUp(self):
+    """Initialize a basic config dict."""
+    super(TestConsulSource, self).setUp()
+    self.config = {
+      'passwd_url': 'PASSWD_URL',
+      'group_url': 'GROUP_URL',
+      'datacenter': 'TEST_DATACENTER',
+      'token': 'TEST_TOKEN',
+    }
+
+  def testDefaultConfiguration(self):
+    source = consulsource.ConsulFilesSource({})
+    self.assertEquals(source.conf['datacenter'],
+                      consulsource.ConsulFilesSource.DATACENTER)
+    self.assertEquals(source.conf['token'],
+                      consulsource.ConsulFilesSource.TOKEN)
+
+  def testOverrideDefaultConfiguration(self):
+    source = consulsource.ConsulFilesSource(self.config)
+    self.assertEquals(source.conf['datacenter'], 'TEST_DATACENTER')
+    self.assertEquals(source.conf['token'], 'TEST_TOKEN')
+    self.assertEquals(source.conf['passwd_url'], 'PASSWD_URL?recurse&token=TEST_TOKEN&dc=TEST_DATACENTER')
+    self.assertEquals(source.conf['group_url'], 'GROUP_URL?recurse&token=TEST_TOKEN&dc=TEST_DATACENTER')
+
+
+class TestPasswdMapParser(unittest.TestCase):
+  def setUp(self):
+    """Set some default avalible data for testing."""
+    self.good_entry = passwd.PasswdMapEntry()
+    self.good_entry.name = 'foo'
+    self.good_entry.passwd = 'x'
+    self.good_entry.uid = 10
+    self.good_entry.gid = 10
+    self.good_entry.gecos = 'How Now Brown Cow'
+    self.good_entry.dir = '/home/foo'
+    self.good_entry.shell = '/bin/bash'
+    self.parser = consulsource.ConsulPasswdMapParser()
+
+  def testGetMap(self):
+    passwd_map = passwd.PasswdMap()
+    cache_info = StringIO.StringIO('''[
+                                   {"Key": "org/users/foo/uid", "Value": "MTA="},
+                                   {"Key": "org/users/foo/gid", "Value": "MTA="},
+                                   {"Key": "org/users/foo/home", "Value": "L2hvbWUvZm9v"},
+                                   {"Key": "org/users/foo/shell", "Value": "L2Jpbi9iYXNo"},
+                                   {"Key": "org/users/foo/comment", "Value": "SG93IE5vdyBCcm93biBDb3c="}
+                                   ]''')
+    self.parser.GetMap(cache_info, passwd_map)
+    self.assertEquals(self.good_entry, passwd_map.PopItem())
+
+  def testReadEntry(self):
+    data = {'uid': '10', 'gid': '10', 'comment': 'How Now Brown Cow', 'shell': '/bin/bash', 'home': '/home/foo', 'passwd': 'x'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(self.good_entry, entry)
+
+  def testDefaultEntryValues(self):
+    data = {'uid': '10', 'gid': '10'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(entry.shell, '/bin/bash')
+    self.assertEquals(entry.dir, '/home/foo')
+    self.assertEquals(entry.gecos, '')
+    self.assertEquals(entry.passwd, 'x')
+
+
+class TestConsulGroupMapParser(unittest.TestCase):
+
+  def setUp(self):
+    self.good_entry = group.GroupMapEntry()
+    self.good_entry.name = 'foo'
+    self.good_entry.passwd = 'x'
+    self.good_entry.gid = 10
+    self.good_entry.members = ['foo', 'bar']
+    self.parser = consulsource.ConsulGroupMapParser()
+
+  def testGetMap(self):
+    group_map = group.GroupMap()
+    cache_info = StringIO.StringIO('''[
+                                   {"Key": "org/groups/foo/gid", "Value": "MTA="},
+                                   {"Key": "org/groups/foo/members", "Value": "Zm9vCmJhcg=="}
+                                   ]''')
+    self.parser.GetMap(cache_info, group_map)
+    self.assertEquals(self.good_entry, group_map.PopItem())
+
+  def testReadEntry(self):
+    data = {'passwd': 'x', 'gid': '10', 'members': 'foo\nbar'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(self.good_entry, entry)
+
+  def testDefaultPasswd(self):
+    data = {'gid': '10', 'members': 'foo\nbar'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(self.good_entry, entry)
+
+  def testNoMembers(self):
+    data = {'gid': '10', 'members': ''}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(entry.members, [''])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/nss_cache/sources/source_factory.py
+++ b/nss_cache/sources/source_factory.py
@@ -48,12 +48,14 @@ def RegisterImplementation(source):
   _source_implementations[source.name] = source
 
 
-# Discover all the known implementations of sources. 
+# Discover all the known implementations of sources.
 from nss_cache.sources import httpsource
 from nss_cache.sources import ldapsource
+from nss_cache.sources import consulsource
 
 httpsource.RegisterImplementation(RegisterImplementation)
 ldapsource.RegisterImplementation(RegisterImplementation)
+consulsource.RegisterImplementation(RegisterImplementation)
 
 # Don't load the zsync source if zsync python module isn't there.
 try:
@@ -61,7 +63,7 @@ try:
   zsyncsource.RegisterImplementation(RegisterImplementation)
 except ImportError:
   pass
-  
+
 
 def Create(conf):
   """Source creation factory method.


### PR DESCRIPTION
This adds a new source for Consul's KV store, based on the HTTP source, which uses Consul's API to pull data. User information is assumed to be stored with the following format:

`NAME/ENTRY = 'VALUE'`
ie
`foo/uid = '10'`
`foo/shell = '/bin/bash'`

Entries are fetched recursively so they can be nested under other keys for organization. Currently only passwd and group are implemented (since that was all I had a need for) but it wouldn't be difficult to add in the remaining types. I wanted to see if there was any feedback first.
