### PR TITLE
Support uniquemember

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -589,7 +589,7 @@ class GroupUpdateGetter(UpdateGetter):
     super(GroupUpdateGetter, self).__init__(conf)
     if conf.get('rfc2307bis'):
       self.attrs = ['cn', 'gidNumber', 'member']
-    elif conf.get('rfc2307bis-alt'):
+    elif conf.get('rfc2307bis_alt'):
       self.attrs = ['cn', 'gidNumber', 'uniqueMember']
     else:
       self.attrs = ['cn', 'gidNumber', 'memberUid']
@@ -634,19 +634,19 @@ class GroupUpdateGetter(UpdateGetter):
  
   def PostProcess(self, data_map, source, search_filter, search_scope):
     """Perform some post-process of the data."""
-
-    for gr in data_map:
-      uidmembers=[]
-      for member in gr.members:
-        source.Search(search_base=member,
-                      search_filter='(objectClass=*)',
-                      search_scope=ldap.SCOPE_BASE,
-                      attrs=['uid'])
-        for obj in source:
-          if 'uid' in obj:
-            uidmembers.extend(obj['uid'])
-      del gr.members[:]
-      gr.members.extend(uidmembers)
+    if 'uniqueMember' in self.attrs:
+      for gr in data_map:
+        uidmembers=[]
+        for member in gr.members:
+          source.Search(search_base=member,
+                        search_filter='(objectClass=*)',
+                        search_scope=ldap.SCOPE_BASE,
+                        attrs=['uid'])
+          for obj in source:
+            if 'uid' in obj:
+              uidmembers.extend(obj['uid'])
+        del gr.members[:]
+        gr.members.extend(uidmembers)
 
 
 class ShadowUpdateGetter(UpdateGetter):

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -587,6 +587,7 @@ class GroupUpdateGetter(UpdateGetter):
 
   def __init__(self, conf):
     super(GroupUpdateGetter, self).__init__(conf)
+    # TODO: Merge multiple rcf2307bis[_alt] options into a single option.
     if conf.get('rfc2307bis'):
       self.attrs = ['cn', 'gidNumber', 'member']
     elif conf.get('rfc2307bis_alt'):

--- a/nss_cache/sources/ldapsource_test.py
+++ b/nss_cache/sources/ldapsource_test.py
@@ -285,7 +285,7 @@ class TestLdapSource(mox.MoxTestBase):
     first = data.PopItem()
 
     self.assertEqual('Testguy McTest', first.name)
- 
+
   def testGetGroupMap(self):
     test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
                         {'gidNumber': [1000],

--- a/nss_cache/sources/ldapsource_test.py
+++ b/nss_cache/sources/ldapsource_test.py
@@ -285,7 +285,7 @@ class TestLdapSource(mox.MoxTestBase):
     first = data.PopItem()
 
     self.assertEqual('Testguy McTest', first.name)
-
+ 
   def testGetGroupMap(self):
     test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
                         {'gidNumber': [1000],
@@ -332,6 +332,133 @@ class TestLdapSource(mox.MoxTestBase):
     ent = data.PopItem()
 
     self.assertEqual('testgroup', ent.name)
+ 
+  def testGetGroupMapBis(self):
+    test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
+                        {'gidNumber': [1000],
+                         'cn': ['testgroup'],
+                         'member': ['cn=testguy,ou=People,dc=example,dc=com', 
+                                    'cn=fooguy,ou=People,dc=example,dc=com',
+                                    'cn=barguy,ou=People,dc=example,dc=com'],
+                         'modifyTimestamp': ['20070227012807Z']})
+
+    config = dict(self.config)
+    config['rfc2307bis'] = 1
+    attrlist = ['cn', 'gidNumber', 'member',
+                'modifyTimestamp']
+
+    mock_rlo = self.mox.CreateMock(ldap.ldapobject.ReconnectLDAPObject)
+    mock_rlo.simple_bind_s(
+        cred='TEST_BIND_PASSWORD',
+        who='TEST_BIND_DN')
+    mock_rlo.search(base='TEST_BASE',
+                    filterstr='TEST_FILTER',
+                    scope=ldap.SCOPE_ONELEVEL,
+                    attrlist=mox.SameElementsAs(attrlist)).AndReturn(
+                        'TEST_RES')
+
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_ENTRY, [test_posix_group]))
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_RESULT, None))
+
+    self.mox.StubOutWithMock(ldap, 'ldapobject')
+    ldap.ldapobject.ReconnectLDAPObject(
+        uri='TEST_URI',
+        retry_max='TEST_RETRY_MAX',
+        retry_delay='TEST_RETRY_DELAY').AndReturn(mock_rlo)
+
+    self.mox.ReplayAll()
+
+    source = ldapsource.LdapSource(config)
+    data = source.GetGroupMap()
+
+    self.assertEqual(1, len(data))
+
+    ent = data.PopItem()
+
+    self.assertEqual('testgroup', ent.name)
+    self.assertEqual(3, len(ent.members))
+
+
+
+  def testGetGroupMapBisAlt(self):
+    test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
+                        {'gidNumber': [1000],
+                         'cn': ['testgroup'],
+                         'uniqueMember': 
+                         ['cn=testguy,ou=People,dc=example,dc=com'], 
+                         'modifyTimestamp': ['20070227012807Z']})
+    dn_user = 'cn=testguy,ou=People,dc=example,dc=com'
+    test_posix_account = (dn_user,
+                          {'uidNumber': [1000],
+                           'gidNumber': [1000],
+                           'uid': ['test'],
+                           'cn': ['testguy'],
+                           'homeDirectory': ['/home/test'],
+                           'loginShell': ['/bin/sh'],
+                           'userPassword': ['p4ssw0rd'],
+                           'modifyTimestamp': ['20070227012807Z']})
+
+    config = dict(self.config)
+    config['rfc2307bis_alt'] = 1
+    attrlist = ['cn', 'gidNumber', 'uniqueMember',
+                'modifyTimestamp']
+    uidattr  = ['uid']
+
+    mock_rlo = self.mox.CreateMock(ldap.ldapobject.ReconnectLDAPObject)
+    mock_rlo.simple_bind_s(
+        cred='TEST_BIND_PASSWORD',
+        who='TEST_BIND_DN')
+    mock_rlo.search(base='TEST_BASE',
+                    filterstr='TEST_FILTER',
+                    scope=ldap.SCOPE_ONELEVEL,
+                    attrlist=mox.SameElementsAs(attrlist)).AndReturn(
+                        'TEST_RES')
+
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_ENTRY, [test_posix_group]))
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_RESULT, None))
+    mock_rlo.search(base=dn_user,
+                    filterstr='(objectClass=*)',
+                    scope=ldap.SCOPE_BASE,
+                    attrlist=mox.SameElementsAs(uidattr)).AndReturn(
+                        'TEST_RES')
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_ENTRY, [test_posix_account]))
+    mock_rlo.result('TEST_RES',
+                    all=0,
+                    timeout='TEST_TIMELIMIT').AndReturn(
+                        (ldap.RES_SEARCH_RESULT, None))
+
+    self.mox.StubOutWithMock(ldap, 'ldapobject')
+    ldap.ldapobject.ReconnectLDAPObject(
+        uri='TEST_URI',
+        retry_max='TEST_RETRY_MAX',
+        retry_delay='TEST_RETRY_DELAY').AndReturn(mock_rlo)
+
+    self.mox.ReplayAll()
+
+    source = ldapsource.LdapSource(config)
+    data = source.GetGroupMap()
+
+    self.assertEqual(1, len(data))
+
+    ent = data.PopItem()
+
+    self.assertEqual('testgroup', ent.name)
+    self.assertEqual(1, len(ent.members))
 
   def testGetShadowMap(self):
     test_shadow = ('cn=test,ou=People,dc=example,dc=com',

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -92,6 +92,11 @@ ldap_filter = (objectclass=posixAccount)
 # in 'member' attr), set this to 1
 #ldap_rfc2307bis = 0
 
+# Default uses rfc2307 schema. If rfc2307bis_alt (groups stored as a list of DNs
+# in 'uniqueMember' attr), set this to 1
+#ldap_rfc2307bis_alt = 0
+
+
 # Debug logging
 #ldap_debug = 3
 

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -96,7 +96,6 @@ ldap_filter = (objectclass=posixAccount)
 # in 'uniqueMember' attr), set this to 1
 #ldap_rfc2307bis_alt = 0
 
-
 # Debug logging
 #ldap_debug = 3
 


### PR DESCRIPTION
Following issue #46  - here is something which has been tested and hopefully understandable.  Maybe need to remove the extra config option (maybe just have a different value for the existing option) and whether we really want to postprocess the group data I am not sure since out cn and uid are the same in my organisation but advice welcome.