### PR TITLE
Safe file remove

### DIFF
--- a/nss_cache/caches/caches.py
+++ b/nss_cache/caches/caches.py
@@ -113,7 +113,11 @@ class Cache(object):
     self.log.debug('rolling back, deleting temp cache file %r',
                    self.temp_cache_filename)
     self.temp_cache_file.close()
-    os.unlink(self.temp_cache_filename)
+    try:
+      os.remove(self.temp_cache_filename)
+    except OSError as e:  # this would be "except OSError, e:" before Python 2.6
+      if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
+        raise  # re-raise exception if a different error occured
 
   def _Commit(self):
     """Ensure the cache is now the active data source for NSS.

--- a/nss_cache/caches/caches.py
+++ b/nss_cache/caches/caches.py
@@ -113,10 +113,11 @@ class Cache(object):
     self.log.debug('rolling back, deleting temp cache file %r',
                    self.temp_cache_filename)
     self.temp_cache_file.close()
+    # Safe file remove (ignore "no such file or directory" errors):
     try:
       os.remove(self.temp_cache_filename)
-    except OSError as e:  # this would be "except OSError, e:" before Python 2.6
-      if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
+    except OSError, e:
+      if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
         raise  # re-raise exception if a different error occured
 
   def _Commit(self):


### PR DESCRIPTION
During certain exceptions, Cache._Rollback would fail to unlink a temp file that didn't yet exist.

Without this fix, the failed file removal obscured the real exception, requiring extra debugging efforts (apparently some exception handlers try to clean up our temp files).

With a maintainer's interest, it might be worth it to define this in some kind of tools file and use it everywhere in place of os.unlink, but this patch is enough for me for now.

Reference: http://stackoverflow.com/questions/10840533/most-pythonic-way-to-delete-a-file-which-may-not-exist