### PR TITLE
Issue #52 Fix case-insensitive modifyTimestamp

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -503,7 +503,10 @@ class UpdateGetter(object):
           logging.warn('invalid object passed: %r not in %r', field, obj)
           raise ValueError('Invalid object passed: %r', obj)
 
-      obj_ts = self.FromLdapToTimestamp(obj['modifyTimestamp'][0])
+      try:
+        obj_ts = self.FromLdapToTimestamp(obj['modifyTimestamp'][0])
+      except KeyError:
+        obj_ts = self.FromLdapToTimestamp(obj['modifyTimeStamp'][0])
 
       if max_ts is None or obj_ts > max_ts:
         max_ts = obj_ts


### PR DESCRIPTION
Active Directory apparently serves 'modifyTimeStamp' whereas other implementations serve 'modifyTimeStamp'. We now try both. Three cheers for case-insensitivity.

See Issue #52. There's no simple case-insensitive dictionary lookup in Python, so I just took the KISS route.