### PR TITLE
UpdateGetter.FromLdapToTimestamp Time Stamp Format Fix

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -435,7 +435,14 @@ class UpdateGetter(object):
     Returns:
       number of seconds since epoch.
     """
-    t = time.strptime(ldap_ts_string, '%Y%m%d%H%M%SZ')
+    try:
+      t = time.strptime(ldap_ts_string, '%Y%m%d%H%M%SZ')
+    except ValueError:
+      # Some systems add a decimal component; try to filter it:
+      m = re.match('([0-9]*)(\.[0-9]*)?(Z)', ldap_ts_string)
+      if m:
+        ldap_ts_string = m.group(1) + m.group(3)
+      t = time.strptime(ldap_ts_string, '%Y%m%d%H%M%SZ')
     return int(calendar.timegm(t))
 
   def FromTimestampToLdap(self, ts):


### PR DESCRIPTION
`UpdateGetter.FromLdapToTimestamp` now works with time stamp format `'%Y%m%d%H%M%S.[0-9]*Z'` (used by Active Directory).

Active Directory gives strings like `'20151002151745.0Z'`. The extra `.0` was causing strptime to fail. ldapsource.py will now work with either format.

strptime also has a '%f' for microseconds, but
1. Using that would require converting the decimal value to integer microseconds,
2. My research indicates that strptime doesn't do anything with the microseconds anyway,
3. Plain seconds has worked just fine so far, and
4. My site's AD server only reports a constant '.0' anyway, so we wouldn't gain anything.