### PR TITLE
mkdir -p timestamp_dir

### DIFF
--- a/nss_cache/update/updater.py
+++ b/nss_cache/update/updater.py
@@ -23,6 +23,7 @@ Updater:  Base class with setup and timestamp code.
 FileMapUpdater:  Class used for all single map caches.
 AutomountMapUpdater:  Class used for updating automount map caches.
 """
+import errno
 
 __author__ = ('vasilios@google.com (V Hoffman)',
               'jaq@google.com (Jamie Wilkinson)')
@@ -163,6 +164,15 @@ class Updater(object):
     Returns:
        A boolean indicating success of write.
     """
+    # Make sure self.timestamp_dir exists before calling tempfile.mkstemp
+    try:
+        os.makedirs(self.timestamp_dir)
+    except OSError, e:
+        if e.errno == errno.EEXIST and os.path.isdir(self.timestamp_dir):
+            pass  # Directory already exists; squelch error
+        else:
+          raise
+
     (filedesc, temp_filename) = tempfile.mkstemp(prefix='nsscache-update-',
                                                  dir=self.timestamp_dir)
     time_string = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(timestamp))


### PR DESCRIPTION
If timestamp_dir (configured in /etc/nsscache.conf) doesn't exist, `nsscache` fails with a sort-of helpful `OSError: [Errno 2] No such file or directory: '/var/lib/nsscache/nsscache-update-Ekxp49'`.

I lost a little time figuring out that I just need to make the directory. This patch makes the directory automatically, simulating `mkdir -p` behavior.

I noticed similar code in `nss_cache/util/timestamps.py` in a method named WriteTimestamp. As far as I can tell, the timestamps.py version is unused. It's pretty close to duplicate code; timestamps.py may have been designed to abstract out the methods as used by updater.py. IDK.

More error text:
````
Traceback (most recent call last):
  File "/usr/local/bin/nsscache", line 33, in <module>
    return_value = nsscache_app.Run(sys.argv[1:], os.environ)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/app.py", line 240, in Run
    retval = command_callable().Run(conf=conf, args=args)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/command.py", line 230, in Run
    force_lock=options.force_lock)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/command.py", line 303, in UpdateMaps
    force_write=force_write)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/update/updater.py", line 265, in UpdateFromSource
    force_write, location=None)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/update/map_updater.py", line 76, in UpdateCacheFromSource
    return_val += self.FullUpdateFromMap(cache, source_map, force_write)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/update/map_updater.py", line 145, in FullUpdateFromMap
    self.WriteModifyTimestamp(new_map.GetModifyTimestamp())
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/update/updater.py", line 240, in WriteModifyTimestamp
    return self._WriteTimestamp(timestamp, self.modify_file)
  File "/usr/local/lib/python2.7/dist-packages/nss_cache/update/updater.py", line 167, in _WriteTimestamp
    dir=self.timestamp_dir)
  File "/usr/lib/python2.7/tempfile.py", line 308, in mkstemp
    return _mkstemp_inner(dir, prefix, suffix, flags)
  File "/usr/lib/python2.7/tempfile.py", line 239, in _mkstemp_inner
    fd = _os.open(file, flags, 0600)
OSError: [Errno 2] No such file or directory: '/var/lib/nsscache/nsscache-update-Ekxp49'
````