### PR TITLE
Documentation and convenience updates

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -487,9 +487,9 @@ class UpdateGetter(object):
 
     if search_scope == 'base':
       search_scope = ldap.SCOPE_BASE
-    elif search_scope == 'one':
+    elif search_scope in ['one', 'onelevel']:
       search_scope = ldap.SCOPE_ONELEVEL
-    elif search_scope == 'sub':
+    elif search_scope in ['sub', 'subtree']:
       search_scope = ldap.SCOPE_SUBTREE
     else:
       raise error.ConfigurationError('Invalid scope: %s' % search_scope)

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -13,7 +13,7 @@
 source = ldap
 
 # Default NSS data cache module name
-cache = cache
+cache = nssdb
 #cache = files
 
 # NSS maps to be cached

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -13,7 +13,7 @@
 source = ldap
 
 # Default NSS data cache module name
-cache = nssdb
+cache = cache
 #cache = files
 
 # NSS maps to be cached

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -19,7 +19,7 @@ The DEFAULT section must provide at least one
 keyword, specifying the data source to use, one
 \fBcache\fP
 keyword, specifying the means in which the cache data will be stored
-locally, and one
+locally, one
 \fBmaps\fP
 keyword, specifying which NSS maps should be cached, and one
 \fBtimestamp_dir\fP
@@ -115,6 +115,11 @@ The search filter to use when querying.
 The search scope to use.  Defaults to
 .I one
 
+Valid options:
+.I sub[tree]
+.I one[level]
+.I base
+
 .TP
 .B ldap_bind_dn
 The bind DN to use when connecting to LDAP.  Emtpy string is an
@@ -153,6 +158,10 @@ Directory for trusted CA certificates.  Defaults to
 .B ldap_tls_cacertfile
 Filename containing trusted CA certificates.  Defaults to
 .I /usr/share/ssl/cert.pem
+
+.TP
+.B ldap_tls_starttls
+Set to 1 to enable STARTTLS. Leave absent to disable.
 
 .TP
 .B ldap_uidattr


### PR DESCRIPTION
A few changes I recorded as I was installing and debugging that should make it easier for future users.

 - nsscache.conf    - Changed default cache value to 'nssdb' from 'cache' -- 'cache' is no longer a valid option in nsscache.conf.5 or config.py.
 - nsscache.conf.5  - Added ldap_tls_starttls, listed ldap_scope valid options, typo fixes.
 - ldapsource.py    - Added synonyms 'onelevel' and 'subtree' to match existing nslcd.conf conventions.

I think I'm almost out of your hair now. :)