### PR TITLE
fixing spelling error, as shown on lintian.debian.org

### DIFF
--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -124,7 +124,7 @@ Valid options:
 
 .TP
 .B ldap_bind_dn
-The bind DN to use when connecting to LDAP.  Emtpy string is an
+The bind DN to use when connecting to LDAP.  Empty string is an
 anonymous bind.  Defaults to the empty string.
 
 .TP


### PR DESCRIPTION
as shown on lintian.debain.org 
https://lintian.debian.org/full/jaq@debian.org.html#nsscache_0.32-1