### PR TITLE
Ignore subkeys on groups/users in Consul that aren't part of the mapping.

### DIFF
--- a/nss_cache/sources/consulsource.py
+++ b/nss_cache/sources/consulsource.py
@@ -138,11 +138,17 @@ class ConsulPasswdMapParser(ConsulMapParser):
     # maps expect strict typing, so convert to int as appropriate.
     map_entry.name = name
     map_entry.passwd = entry.get('passwd', 'x')
-    map_entry.uid = int(entry['uid'])
-    map_entry.gid = int(entry['gid'])
+
+    try:
+      map_entry.uid = int(entry['uid'])
+      map_entry.gid = int(entry['gid'])
+    except (ValueError, KeyError):
+      return None
+
     map_entry.gecos = entry.get('comment', '')
     map_entry.dir = entry.get('home', '/home/{}'.format(name))
     map_entry.shell = entry.get('shell', '/bin/bash')
+
     return map_entry
 
 
@@ -156,7 +162,12 @@ class ConsulGroupMapParser(ConsulMapParser):
     # map entries expect strict typing, so convert as appropriate
     map_entry.name = name
     map_entry.passwd = entry.get('passwd', 'x')
-    map_entry.gid = int(entry['gid'])
+
+    try:
+      map_entry.gid = int(entry['gid'])
+    except (ValueError, KeyError):
+      return None
+
     try:
       members = entry.get('members', '').split('\n')
     except (ValueError, TypeError):

--- a/nss_cache/sources/consulsource_test.py
+++ b/nss_cache/sources/consulsource_test.py
@@ -57,7 +57,8 @@ class TestPasswdMapParser(unittest.TestCase):
                                    {"Key": "org/users/foo/gid", "Value": "MTA="},
                                    {"Key": "org/users/foo/home", "Value": "L2hvbWUvZm9v"},
                                    {"Key": "org/users/foo/shell", "Value": "L2Jpbi9iYXNo"},
-                                   {"Key": "org/users/foo/comment", "Value": "SG93IE5vdyBCcm93biBDb3c="}
+                                   {"Key": "org/users/foo/comment", "Value": "SG93IE5vdyBCcm93biBDb3c="},
+                                   {"Key": "org/users/foo/subkey/irrelevant_key", "Value": "YmFjb24="}
                                    ]''')
     self.parser.GetMap(cache_info, passwd_map)
     self.assertEquals(self.good_entry, passwd_map.PopItem())
@@ -75,6 +76,11 @@ class TestPasswdMapParser(unittest.TestCase):
     self.assertEquals(entry.gecos, '')
     self.assertEquals(entry.passwd, 'x')
 
+  def testInvalidEntry(self):
+    data = {'irrelevant_key': 'bacon'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(entry, None)
+
 
 class TestConsulGroupMapParser(unittest.TestCase):
 
@@ -90,7 +96,8 @@ class TestConsulGroupMapParser(unittest.TestCase):
     group_map = group.GroupMap()
     cache_info = StringIO.StringIO('''[
                                    {"Key": "org/groups/foo/gid", "Value": "MTA="},
-                                   {"Key": "org/groups/foo/members", "Value": "Zm9vCmJhcg=="}
+                                   {"Key": "org/groups/foo/members", "Value": "Zm9vCmJhcg=="},
+                                   {"Key": "org/groups/foo/subkey/irrelevant_key", "Value": "YmFjb24="}
                                    ]''')
     self.parser.GetMap(cache_info, group_map)
     self.assertEquals(self.good_entry, group_map.PopItem())
@@ -109,6 +116,11 @@ class TestConsulGroupMapParser(unittest.TestCase):
     data = {'gid': '10', 'members': ''}
     entry = self.parser._ReadEntry('foo', data)
     self.assertEquals(entry.members, [''])
+
+  def testInvalidEntry(self):
+    data = {'irrelevant_key': 'bacon'}
+    entry = self.parser._ReadEntry('foo', data)
+    self.assertEquals(entry, None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently having a subkey in Consul under, say, a specific user would cause the mapping to try to parse the subkey as another user. That causes exceptions which make the entire update fail.

This change simply ignores any passwd entries that are missing a uid or gid, and any group entries missing a gid. Defaults are already provided for any other missing keys.