### PR TITLE
Add the shadow map to the consul source

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,7 @@ __author__ = 'jaq@google.com (Jamie Wilkinson)'
 
 import logging
 import os
+import sys
 import unittest
 
 
@@ -48,6 +49,7 @@ from nss_cache.maps.shadow_test import *
 
 from nss_cache.sources.source_test import *
 from nss_cache.sources.source_factory_test import *
+from nss_cache.sources.consulsource_test import *
 from nss_cache.sources.httpsource_test import *
 from nss_cache.sources.ldapsource_test import *
 # Unsupported and deprecated.


### PR DESCRIPTION
Allow the consul source module to manage a cache for the shadow database.

With that we can use directly `pam_unix` to do the authentication using what is stored in consul.