### PR TITLE
Add LDAP client certificate support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ a.out
 *.debian.tar.xz
 .pybuild
 debian/debhelper-build-stamp
+*~

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -85,9 +85,6 @@ class LdapSource(source.Source):
   SCOPE = 'one'
   TIMELIMIT = -1
   TLS_REQUIRE_CERT = 'demand'  # one of never, hard, demand, allow, try
-  TLS_CACERTDIR = '/usr/share/ssl'
-  # the ldap client library requires TLS_CACERTDIR to be an absolute path
-  TLS_CACERTFILE = TLS_CACERTDIR + '/cert.pem'
 
   # for registration
   name = 'ldap'
@@ -155,10 +152,6 @@ class LdapSource(source.Source):
       configuration['timelimit'] = -1
     if not 'tls_require_cert' in configuration:
       configuration['tls_require_cert'] = self.TLS_REQUIRE_CERT
-    if not 'tls_cacertdir' in configuration:
-      configuration['tls_cacertdir'] = self.TLS_CACERTDIR
-    if not 'tls_cacertfile' in configuration:
-      configuration['tls_cacertfile'] = self.TLS_CACERTFILE
     if not 'tls_starttls' in configuration:
       configuration['tls_starttls'] = 0
 
@@ -187,8 +180,14 @@ class LdapSource(source.Source):
     # Setting global ldap defaults.
     ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,
                     configuration['tls_require_cert'])
-    ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, configuration['tls_cacertdir'])
-    ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, configuration['tls_cacertfile'])
+    if 'tls_cacertdir' in configuration:
+        ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, configuration['tls_cacertdir'])
+    if 'tls_cacertfile' in configuration:
+        ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, configuration['tls_cacertfile'])
+    if 'tls_certfile' in configuration:
+        ldap.set_option(ldap.OPT_X_TLS_CERTFILE, configuration['tls_certfile'])
+    if 'tls_keyfile' in configuration:
+        ldap.set_option(ldap.OPT_X_TLS_KEYFILE, configuration['tls_keyfile'])
     ldap.version = ldap.VERSION3  # this is hard-coded, we only support V3
 
   def _SetCookie(self, cookie):

--- a/nss_cache/sources/ldapsource_test.py
+++ b/nss_cache/sources/ldapsource_test.py
@@ -89,10 +89,6 @@ class TestLdapSource(mox.MoxTestBase):
                       ldapsource.LdapSource.TIMELIMIT)
     self.assertEquals(source.conf['tls_require_cert'],
                       ldap.OPT_X_TLS_DEMAND)
-    self.assertEquals(source.conf['tls_cacertdir'],
-                      ldapsource.LdapSource.TLS_CACERTDIR)
-    self.assertEquals(source.conf['tls_cacertfile'],
-                      ldapsource.LdapSource.TLS_CACERTFILE)
 
   def testOverrideDefaultConfiguration(self):
     config = dict(self.config)
@@ -129,7 +125,7 @@ class TestLdapSource(mox.MoxTestBase):
         retry_max='TEST_RETRY_MAX',
         retry_delay='TEST_RETRY_DELAY',
         uri='TEST_URI').AndReturn(mock_rlo)
-    
+
     self.mox.ReplayAll()
     source = ldapsource.LdapSource(config)
 
@@ -348,12 +344,12 @@ class TestLdapSource(mox.MoxTestBase):
     ent = data.PopItem()
 
     self.assertEqual('testgroup', ent.name)
- 
+
   def testGetGroupMapBis(self):
     test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
                         {'gidNumber': [1000],
                          'cn': ['testgroup'],
-                         'member': ['cn=testguy,ou=People,dc=example,dc=com', 
+                         'member': ['cn=testguy,ou=People,dc=example,dc=com',
                                     'cn=fooguy,ou=People,dc=example,dc=com',
                                     'cn=barguy,ou=People,dc=example,dc=com'],
                          'modifyTimestamp': ['20070227012807Z']})
@@ -406,8 +402,8 @@ class TestLdapSource(mox.MoxTestBase):
     test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
                         {'gidNumber': [1000],
                          'cn': ['testgroup'],
-                         'uniqueMember': 
-                         ['cn=testguy,ou=People,dc=example,dc=com'], 
+                         'uniqueMember':
+                         ['cn=testguy,ou=People,dc=example,dc=com'],
                          'modifyTimestamp': ['20070227012807Z']})
     dn_user = 'cn=testguy,ou=People,dc=example,dc=com'
     test_posix_account = (dn_user,

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -71,6 +71,10 @@ ldap_filter = (objectclass=posixAccount)
 # Default filename for trusted CAs
 #ldap_tls_cacertfile = '/usr/share/ssl/cert.pem'
 
+# If you wish to use mTLS, set these to the paths of the TLS certificate and key.
+#ldap_tls_certfile = ''
+#ldap_tls_keyfile = ''
+
 # Should we issue STARTTLS?
 #ldap_tls_starttls = 1
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -67,7 +67,7 @@ If the files-module option
 .I files_cache_filename_suffix
 is also set to
 .B cache
-then not only will the files be created with a \fB.cache\fP suffix, but also an index file will be written alongside, for use with the 
+then not only will the files be created with a \fB.cache\fP suffix, but also an index file will be written alongside, for use with the
 .I nss-cache
 NSS module.  (See https://github.com/google/libnss-cache.)
 
@@ -148,18 +148,28 @@ Delay in seconds between retries.  Defaults to 5.
 .TP
 .B ldap_tls_require_cert
 Sets expectations for SSL certificates, using TLS.  One
-of 'never', 'hard', 'demand', 'allow', or 'try'.  See
-\fBldap.conf\fP(5) for more information.
+of 'never', 'hard', 'demand', 'allow', or 'try' ('demand'
+is the default).  See \fBldap.conf\fP(5) for more information.
 
 .TP
 .B ldap_tls_cacertdir
-Directory for trusted CA certificates.  Defaults to
-.I /usr/share/ssl
+Directory for trusted CA certificates.  By default, the system's
+default CA certificate directory will be used.
 
 .TP
 .B ldap_tls_cacertfile
-Filename containing trusted CA certificates.  Defaults to
-.I /usr/share/ssl/cert.pem
+Filename containing trusted CA certificates.
+
+.TP
+.B ldap_tls_certfile
+Filename of an optional LDAP client certificate. If specified,
+\fBldap_tls_keyfile\fP must also be specified.
+
+.TP
+.B ldap_tls_keyfile
+Filename of an optional LDAP client key.  Only plaintext (unencrypted) keys are
+currently supported.  If specified, \fBldap_tls_certfile\fP must also be
+specified.
 
 .TP
 .B ldap_tls_starttls


### PR DESCRIPTION
Add LDAP client certificate support via the `ldap_tls_certfile`
and `ldap_tls_keyfile` configuration options.  This is useful
for those who wish to enable mTLS authentication with the server.