### PR TITLE
Fix resetting of cookie

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -302,7 +302,7 @@ class LdapSource(source.Source):
               # else: An empty cookie means we are done.
 
           # break loop once result3 doesn't time out and reset cookie
-          setCookieOnControl(self.ldap_controls,'',self.PAGE_SIZE)
+          setCookieOnControl(self.ldap_controls, '', self.PAGE_SIZE)
           break
         except ldap.SIZELIMIT_EXCEEDED:
           self.log.warning('LDAP server size limit exceeded; using page size {0}.'.format(self.PAGE_SIZE))

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -301,7 +301,8 @@ class LdapSource(source.Source):
                   self.message_id, all=0, timeout=self.conf['timelimit'])
               # else: An empty cookie means we are done.
 
-          # break loop once result3 doesn't time out
+          # break loop once result3 doesn't time out and reset cookie
+          setCookieOnControl(self.ldap_controls,'',self.PAGE_SIZE)
           break
         except ldap.SIZELIMIT_EXCEEDED:
           self.log.warning('LDAP server size limit exceeded; using page size {0}.'.format(self.PAGE_SIZE))


### PR DESCRIPTION
When performing multiple searches in the same area (such as auto fs), if the result is bigger than the page size for the first search, the cookie is not reset for the subsequent search. 