### PR TITLE
Add `ldap_override_shell` config option

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -655,7 +655,9 @@ class PasswdUpdateGetter(UpdateGetter):
     if hasattr(self, 'uidregex'):
       pw.name = ''.join([x for x in self.uidregex.findall(pw.name)])
 
-    if 'loginShell' in obj:
+    if 'override_shell' in self.conf:
+      pw.shell = self.conf['override_shell']
+    elif 'loginShell' in obj:
       pw.shell = obj['loginShell'][0]
     else:
       pw.shell = ''

--- a/nss_cache/sources/ldapsource_test.py
+++ b/nss_cache/sources/ldapsource_test.py
@@ -302,6 +302,59 @@ class TestLdapSource(mox.MoxTestBase):
 
     self.assertEqual('Testguy McTest', first.name)
 
+  def testGetPasswdMapWithShellOverride(self):
+    test_posix_account = ('cn=test,ou=People,dc=example,dc=com',
+                          {'uidNumber': [1000],
+                           'gidNumber': [1000],
+                           'uid': ['Testguy McTest'],
+                           'cn': ['test'],
+                           'homeDirectory': ['/home/test'],
+                           'loginShell': ['/bin/sh'],
+                           'userPassword': ['p4ssw0rd'],
+                           'modifyTimestamp': ['20070227012807Z']})
+    config = dict(self.config)
+    config['override_shell'] = '/bin/false'
+    attrlist = ['uid', 'uidNumber', 'gidNumber',
+                'gecos', 'cn', 'homeDirectory',
+                'fullName',
+                'loginShell', 'modifyTimestamp']
+
+    mock_rlo = self.mox.CreateMock(ldap.ldapobject.ReconnectLDAPObject)
+    mock_rlo.simple_bind_s(
+        cred='TEST_BIND_PASSWORD',
+        who='TEST_BIND_DN')
+    mock_rlo.search_ext(base='TEST_BASE',
+                        filterstr='TEST_FILTER',
+                        scope=ldap.SCOPE_ONELEVEL,
+                        attrlist=mox.SameElementsAs(attrlist),
+                        serverctrls=mox.Func(self.compareSPRC())).AndReturn('TEST_RES')
+
+    mock_rlo.result3('TEST_RES',
+                     all=0,
+                     timeout='TEST_TIMELIMIT').AndReturn(
+                         (ldap.RES_SEARCH_ENTRY, [test_posix_account], None, []))
+    mock_rlo.result3('TEST_RES',
+                     all=0,
+                     timeout='TEST_TIMELIMIT').AndReturn(
+                         (ldap.RES_SEARCH_RESULT, None, None, []))
+
+    self.mox.StubOutWithMock(ldap, 'ldapobject')
+    ldap.ldapobject.ReconnectLDAPObject(
+        uri='TEST_URI',
+        retry_max='TEST_RETRY_MAX',
+        retry_delay='TEST_RETRY_DELAY').AndReturn(mock_rlo)
+
+    self.mox.ReplayAll()
+
+    source = ldapsource.LdapSource(config)
+    data = source.GetPasswdMap()
+
+    self.assertEqual(1, len(data))
+
+    first = data.PopItem()
+
+    self.assertEqual('/bin/false', first.shell)
+
   def testGetGroupMap(self):
     test_posix_group = ('cn=test,ou=Group,dc=example,dc=com',
                         {'gidNumber': [1000],

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -89,6 +89,9 @@ ldap_filter = (objectclass=posixAccount)
 # the @example.com domain.  Default is no regex.
 #ldap_groupregex = ''
 
+# Replace all users' shells with the specified one.
+#ldap_override_shell='/bin/bash'
+
 # Default uses rfc2307 schema. If rfc2307bis (groups stored as a list of DNs
 # in 'member' attr), set this to 1
 #ldap_rfc2307bis = 0

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -184,6 +184,11 @@ For example:  '(.*)@example.com' would return a member without the
 the @example.com domain.  Default is no regex.
 
 .TP
+.B ldap_override_shell
+If specified, set every user's login shell to the given one.  May be
+useful on bastion hosts or to ensure uniformity.
+
+.TP
 .B ldap_rfc2307bis
 Default uses rfc2307 schema. If rfc2307bis (groups stored as a list of DNs
 in 'member' attr), set this to 1.


### PR DESCRIPTION
Add a `ldap_override_shell` configuration option that allows the
administrator to override the login shell of each user synchronized from
the LDAP service.  This can be useful on bastion hosts or to enforce
site policy.