### PR TITLE
Fix files.py ignoring path

### DIFF
--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -53,11 +53,7 @@ for i in sys.argv:
     parser.read(i)
   else:
     # Config in nsscache folder
-    try:
-      parser.read(config.Config.NSSCACHE_CONFIG)
-    except:
-      parser.read('nsscache.conf')
-      
+    parser.read('nsscache.conf')
 prefix = parser.get('suffix', 'prefix')
 suffix = parser.get('suffix', 'suffix')
 

--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -46,12 +46,14 @@ else: # Python < 2.4, 50% slower
 # Load suffix config variables
 parser = ConfigParser.ConfigParser()
 for i in sys.argv:
-  # Get config path from command line argument
-  if ('conf') in i:
+  if ('nsscache.conf') in i:
+    # Remove '--config-file=' from the string
+    if ('--config-file') in i:
+      i = i[14:] 
     parser.read(i)
   else:
     # Config in nsscache folder
-    parser.read('nsscache.conf')
+    parser.read(config.Config.NSSCACHE_CONFIG)
 prefix = parser.get('suffix', 'prefix')
 suffix = parser.get('suffix', 'suffix')
 

--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -53,7 +53,11 @@ for i in sys.argv:
     parser.read(i)
   else:
     # Config in nsscache folder
-    parser.read(config.Config.NSSCACHE_CONFIG)
+    try:
+      parser.read(config.Config.NSSCACHE_CONFIG)
+    except:
+      parser.read('nsscache.conf')
+      
 prefix = parser.get('suffix', 'prefix')
 suffix = parser.get('suffix', 'suffix')
 

--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -45,7 +45,13 @@ else: # Python < 2.4, 50% slower
 
 # Load suffix config variables
 parser = ConfigParser.ConfigParser()
-parser.read('nsscache.conf')
+for i in sys.argv:
+  # Get config path from command line argument
+  if ('conf') in i:
+    parser.read(i)
+  else:
+    # Config in nsscache folder
+    parser.read('nsscache.conf')
 prefix = parser.get('suffix', 'prefix')
 suffix = parser.get('suffix', 'suffix')
 


### PR DESCRIPTION
The parser that got the prefix and suffix were hardcoded to 'nsscache.conf' which ignored the -c parameter. This fetches the path from sys.argv and uses the path specified. 