### PR TITLE
Nested groups

### DIFF
--- a/nss_cache/maps/group.py
+++ b/nss_cache/maps/group.py
@@ -48,9 +48,9 @@ class GroupMap(maps.Map):
 class GroupMapEntry(maps.MapEntry):
   """This class represents NSS group map entries."""
   # Using slots saves us over 2x memory on large maps.
-  __slots__ = ('name', 'passwd', 'gid', 'members')
+  __slots__ = ('name', 'passwd', 'gid', 'members', 'groupmembers')
   _KEY = 'name'
-  _ATTRS = ('name', 'passwd', 'gid', 'members')
+  _ATTRS = ('name', 'passwd', 'gid', 'members', 'groupmembers')
   
   def __init__(self, data=None):
     """Construct a GroupMapEntry, setting reasonable defaults."""
@@ -58,9 +58,11 @@ class GroupMapEntry(maps.MapEntry):
     self.passwd = None
     self.gid = None
     self.members = None
+    self.groupmembers = None
     
     super(GroupMapEntry, self).__init__(data)
     
     # Seed data with defaults if needed
     if self.passwd is None: self.passwd = 'x'
     if self.members is None: self.members = []
+    if self.groupmembers is None: self.groupmembers = []

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -715,10 +715,9 @@ class GroupUpdateGetter(UpdateGetter):
     elif 'member' in obj:
       for member_dn in obj['member']:
         member_uid = member_dn.split(',')[0].split('=')[1]
-        if base and member_dn.endswith(base):
-          # Only include groups. NB: if ldap_base is not set in the group section, all users and groups
-          # will be added to to the group_members list
-          group_members.append(member_uid)
+        # Note that there is not currently a way to consistently distinguish
+        # a group from a person
+        group_members.append(member_uid)
         if hasattr(self, 'groupregex'):
           members.append(''.join([x for x in self.groupregex.findall(member_uid)]))
         else:

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -703,7 +703,9 @@ class GroupUpdateGetter(UpdateGetter):
     gr.name = obj['cn'][0]
     # group passwords are deferred to gshadow
     gr.passwd = '*'
+    base = self.conf.get("base")
     members = []
+    group_members = []
     if 'memberUid' in obj:
       if hasattr(self, 'groupregex'):
         members.extend(''.join([x for x in self.groupregex.findall(obj['memberUid'])]))
@@ -712,6 +714,9 @@ class GroupUpdateGetter(UpdateGetter):
     elif 'member' in obj:
       for member_dn in obj['member']:
         member_uid = member_dn.split(',')[0].split('=')[1]
+        if base and member_dn.endswith(base):
+          group_members.append(member_uid)
+          continue
         if hasattr(self, 'groupregex'):
           members.append(''.join([x for x in self.groupregex.findall(member_uid)]))
         else:
@@ -723,6 +728,7 @@ class GroupUpdateGetter(UpdateGetter):
 
     gr.gid = int(obj['gidNumber'][0])
     gr.members = members
+    gr.groupmembers = group_members
 
     return gr
 
@@ -741,6 +747,23 @@ class GroupUpdateGetter(UpdateGetter):
               uidmembers.extend(obj['uid'])
         del gr.members[:]
         gr.members.extend(uidmembers)
+    
+    _group_map = {i.name: i for i in data_map}
+    
+    def _expand_members(obj, visited=None):
+      """Expand all subgroups recursively"""
+      for member_name in obj.groupmembers:
+        if member_name in _group_map and member_name not in visited:
+          gmember = _group_map[member_name]
+          for member in gmember.members:
+            if member not in obj.members:
+              obj.members.append(member)
+          for submember_name in gmember.groupmembers:
+            if submember_name in _group_map and submember_name not in visited:
+              visited.append(submember_name)
+              _expand_members(_group_map[submember_name], visited)
+    for gr in data_map:
+      _expand_members(gr, [gr.name])
 
 
 class ShadowUpdateGetter(UpdateGetter):

--- a/nss_cache/sources/ldapsource_test.py
+++ b/nss_cache/sources/ldapsource_test.py
@@ -868,7 +868,7 @@ class TestUpdateGetter(unittest.TestCase):
     data = getter.GetUpdates(self.source, 'TEST_BASE',
                              'TEST_FILTER', 'base', None)
 
-    self.failUnlessEqual(passwd.PasswdMap, type(data))
+    self.assertEqual(passwd.PasswdMap, type(data))
 
   def testGroupEmptySourceGetUpdates(self):
     """Test that getUpdates on the GroupUpdateGetter works."""
@@ -877,7 +877,7 @@ class TestUpdateGetter(unittest.TestCase):
     data = getter.GetUpdates(self.source, 'TEST_BASE',
                              'TEST_FILTER', 'base', None)
 
-    self.failUnlessEqual(group.GroupMap, type(data))
+    self.assertEqual(group.GroupMap, type(data))
 
   def testShadowEmptySourceGetUpdates(self):
     """Test that getUpdates on the ShadowUpdateGetter works."""
@@ -886,7 +886,7 @@ class TestUpdateGetter(unittest.TestCase):
     data = getter.GetUpdates(self.source, 'TEST_BASE',
                              'TEST_FILTER', 'base', None)
 
-    self.failUnlessEqual(shadow.ShadowMap, type(data))
+    self.assertEqual(shadow.ShadowMap, type(data))
 
   def testAutomountEmptySourceGetsUpdates(self):
     """Test that getUpdates on the AutomountUpdateGetter works."""
@@ -895,7 +895,7 @@ class TestUpdateGetter(unittest.TestCase):
     data = getter.GetUpdates(self.source, 'TEST_BASE',
                              'TEST_FILTER', 'base', None)
 
-    self.failUnlessEqual(automount.AutomountMap, type(data))
+    self.assertEqual(automount.AutomountMap, type(data))
 
   def testBadScopeException(self):
     """Test that a bad scope raises a config.ConfigurationError."""

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -146,6 +146,11 @@ files_cache_filename_suffix = cache
 
 ldap_base = ou=group,dc=example,dc=com
 ldap_filter = (objectclass=posixGroup)
+# If ldap_nested_groups is enabled, any groups are members of other groups
+# will be expanded recursively.
+# Note: This will only work with full updates. Incremental updates will not
+# propagate changes in child groups to their parents.
+# ldap_nested_groups = 1
 
 [shadow]
 

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -194,6 +194,12 @@ For example:  '(.*)@example.com' would return a member without the
 the @example.com domain.  Default is no regex.
 
 .TP
+.B ldap_nested_groups
+To enable expansion of nested groups, set this to 1. Note that this only
+applies during a full sync, and incremental synchronization should not be used
+if this is set.
+
+.TP
 .B ldap_override_shell
 If specified, set every user's login shell to the given one.  May be
 useful on bastion hosts or to ensure uniformity.
@@ -323,6 +329,7 @@ A typical example might look like this:
   [group]
   ldap_base = ou=Group,dc=example,dc=com
   ldap_filter = (objectclass=posixGroup)
+  ldap_nested_groups = 1
 
   [shadow]
   ldap_filter = (objectclass=posixAccount)


### PR DESCRIPTION
Provisionally support nested groups -- for #68 

Caveats:
1. Currently, this will only work with the `--full` update option. Because the entire group map is not available with incremental updates, the updater will not be able to recursively update parent groups when a child group's membership changes
2. This is enabled with the config flag `ldap_nested_groups` under the `[group]` section