### PR TITLE
Added AD support

### DIFF
--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -53,7 +53,7 @@ for i in sys.argv:
     parser.read(i)
   else:
     # Config in nsscache folder
-    parser.read('nsscache.conf')
+    parser.read('/etc/nsscache.conf')
 prefix = parser.get('suffix', 'prefix')
 suffix = parser.get('suffix', 'suffix')
 

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -806,11 +806,11 @@ class GroupUpdateGetter(UpdateGetter):
 
     if self.conf.get('ad'):
       if self.conf.get('gidnumber'):
-        gr.gid = int(obj['gidnumber'][0])
+        gr.gid = int(obj['gidNumber'][0])
       else:
         gr.gid = int(sidToStr(obj['objectSid'][0]).split('-')[-1])
     else:
-      gr.gid = int(obj['gidnumber'][0])
+      gr.gid = int(obj['gidNumber'][0])
 
     if 'offset' in self.conf:
       gr.gid = int(gr.gid + self.conf['offset'])

--- a/nsscache.conf
+++ b/nsscache.conf
@@ -32,6 +32,10 @@ timestamp_dir = /var/lib/nsscache
 # ldap module defaults.
 #
 
+# Enable to connect to Active Directory.
+# Leave disabled if connecting to openldap or slapd
+#ldap_ad = 1
+
 # LDAP URI to query for NSS data
 ldap_uri = ldaps://ldap
 
@@ -81,6 +85,15 @@ ldap_filter = (objectclass=posixAccount)
 # Default uid-like attribute
 #ldap_uidattr = 'uid'
 
+# For Active Directory if disabled, RID will be
+# used for users and groups uidNumber uidNumber and gidNumber.
+# Enable (set to 1) to use uidNumber and gidNumber instead.
+#ldap_uidnumber = 0
+#ldap_gidnumber = 0
+
+# Default Offset option to map uid and gid to higher number.
+#ldap_offest = 10000
+
 # A Python regex to extract uid components from the uid-like attribute.
 # All matching groups are concatenated without spaces.
 # For example:  '(.*)@example.com' would return a uid to the left of
@@ -95,6 +108,9 @@ ldap_filter = (objectclass=posixAccount)
 
 # Replace all users' shells with the specified one.
 #ldap_override_shell='/bin/bash'
+
+# Set directory for all users in passwd under /home.
+#ldap_home_dir = 1
 
 # Default uses rfc2307 schema. If rfc2307bis (groups stored as a list of DNs
 # in 'member' attr), set this to 1

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -101,6 +101,17 @@ These options configure the behaviour of the
 source.
 
 .TP
+.B ldap_ad
+Type of Directory to connect to. 1 means Active Directory.
+Leave disabled if connecting to
+.I openldap
+or
+.I slapd.
+If this option is enabled, sAMAccountName will be mapped to uid.
+RID will be mapped to uidNumber and gidNumber. To override, enable
+the options \fBldap_uidNumber\fP and \fBldap_gidNumber\fP.
+
+.TP
 .B ldap_uri
 The LDAP URI to connect to.
 
@@ -177,7 +188,24 @@ Set to 1 to enable STARTTLS. Leave absent to disable.
 
 .TP
 .B ldap_uidattr
-The uid-like attribute in your directory.  Defaults to uid.
+The uid-like attribute in your directory. Defaults to uid.
+
+.TP
+.B ldap_uidnumber
+Only relevant for Active Directory. if enabled (set to 1),
+the uidNumber attribute will be used instead of the relative identifier (RID).
+It has no effect if the option \fBldap_ad\fP is disabled.
+
+.TP
+.B ldap_gidnumber
+Only relevant for Active Directory. if enabled (set to 1),
+the gidNumber attribute will be used instead of the relative identifier (RID).
+It has no effect if the option \fBldap_ad\fP is disabled.
+
+.TP
+.B ldap_offset
+Default Offset option to map uidNumber and gidNumber to higher number.
+This is useful to avoid conflict with already existing uidNumber and gidNumber.
 
 .TP
 .B ldap_uidregex
@@ -203,6 +231,12 @@ if this is set.
 .B ldap_override_shell
 If specified, set every user's login shell to the given one.  May be
 useful on bastion hosts or to ensure uniformity.
+
+.TP
+.B ldap_home_dir
+Set a home directory for all users in passwd. If enabled (set to 1),
+all users will have their home directory in
+.I /home.
 
 .TP
 .B ldap_rfc2307bis


### PR DESCRIPTION
Hi,

I've added the AD support in `ldapsource.py.` I modified `nsscache.conf` and `nsscache.conf.5` accordingly as well. Further more I made a minor change in `files.py`. 

When enable the option `ldap_ad` the following attributes will be mapped as follows:
* `sAMAccountName` will be mapped to NSS `uid`
* `RID` will be mapped to `uidNumber` and `gidNumber` unless the options `ldap_uidNumber` or `ldap_gidNumber` are enabled or one of them. This will map the classical `uidNumber` and `gidNumber` if present instead
* `displayName` will be mapped to `gecos`
* `sAMAccountName` will be mapped to group name `uid`
* `pwdLastSet` will be mapped to `shadowLastChange`

I added more options to `nsscache.conf` and modified the `nsscache.conf.5` accordingly:
* `ldap_home_dir` will set the home directory for all mapped users in `/home`
* `ldap_offest` this will enable to map the `uidNumber` and `gidNumber` to a higher number to avoid conflict with existing values. Their value will be added to the offset value
* `ldap_uidnumber` and `ldap_gidnumber` when enabled their values will be used for mapping instead of the `RID` and only relevant for Active Directory and has only effect if `ldap_ad` is enabled
 
Please let me know if any thing needs to be modified.
Sorry for the initial difficulties.

Best