### PR TITLE
convert all members of a group to string

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -397,9 +397,15 @@ class LdapSource(source.Source):
         # If the dn is requested, return it along with the payload,
         # otherwise ignore it.
         for key in record[1]:
-          if isinstance(record[1][key][0], bytes) and key != 'objectSid':
-            value = record[1][key][0].decode('utf-8')
-            record[1][key] = [value]
+          if len(record[1][key]) > 1:
+            for i, item in enumerate(record[1][key]):
+              if isinstance(item, bytes) and key != 'objectSid':
+                value = item.decode('utf-8')
+                record[1][key][i] = value
+          else:
+            if isinstance(record[1][key][0], bytes) and key != 'objectSid':
+              value = record[1][key][0].decode('utf-8')
+              record[1][key] = [value]
         if self._dn_requested:
           merged_records = {'dn': record[0]}
           merged_records.update(record[1])

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -397,9 +397,9 @@ class LdapSource(source.Source):
         # If the dn is requested, return it along with the payload,
         # otherwise ignore it.
         for key in record[1]:
-          for i, item in enumerate(record[1][key]):
-            if isinstance(item, bytes) and key != 'objectSid':
-              value = item.decode('utf-8')
+          for i in range(len(record[1][key])):
+            if isinstance(record[1][key][i], bytes) and key != 'objectSid':
+              value = record[1][key][i].decode('utf-8')
               record[1][key][i] = value
         if self._dn_requested:
           merged_records = {'dn': record[0]}

--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -397,15 +397,10 @@ class LdapSource(source.Source):
         # If the dn is requested, return it along with the payload,
         # otherwise ignore it.
         for key in record[1]:
-          if len(record[1][key]) > 1:
-            for i, item in enumerate(record[1][key]):
-              if isinstance(item, bytes) and key != 'objectSid':
-                value = item.decode('utf-8')
-                record[1][key][i] = value
-          else:
-            if isinstance(record[1][key][0], bytes) and key != 'objectSid':
-              value = record[1][key][0].decode('utf-8')
-              record[1][key] = [value]
+          for i, item in enumerate(record[1][key]):
+            if isinstance(item, bytes) and key != 'objectSid':
+              value = item.decode('utf-8')
+              record[1][key][i] = value
         if self._dn_requested:
           merged_records = {'dn': record[0]}
           merged_records.update(record[1])

--- a/nsscache
+++ b/nsscache
@@ -1,4 +1,4 @@
-#!/usr/bin/python -E
+#!/usr/bin/python3
 #
 # Copyright 2007 Google Inc.
 #
@@ -28,9 +28,9 @@ from nss_cache import app
 
 if __name__ == '__main__':
   nsscache_app = app.NssCacheApp()
-  start_time = time.clock()
+  start_time = time.process_time()
   return_value = nsscache_app.Run(sys.argv[1:], os.environ)
-  end_time = time.clock()
+  end_time = time.process_time()
   nsscache_app.log.info('Exiting nsscache with value %d runtime %f',
                         return_value, end_time - start_time)
   sys.exit(return_value)


### PR DESCRIPTION
This is the critical part:
```
      for record in data:
        # If the dn is requested, return it along with the payload,
        # otherwise ignore it.
        for key in record[1]:
          if isinstance(record[1][key][0], bytes) and key != 'objectSid':
            value = record[1][key][0].decode('utf-8')
            record[1][key] = [value]
        if self._dn_requested:
          merged_records = {'dn': record[0]}
          merged_records.update(record[1])
          yield merged_records
        else:
          yield record[1]
```
member list is > 1, so it converts the first member only, we need to check the length of the list, as for members it is not always 1, as for the other attributes. My solution would be:
```
      for record in data:
        # If the dn is requested, return it along with the payload,
        # otherwise ignore it.
        for key in record[1]:
          if len(record[1][key]) > 1:
            for i, item in enumerate(record[1][key]):
              if isinstance(item, bytes) and key != 'objectSid':
                value = item.decode('utf-8')
                record[1][key][i] = value
          else:
            if isinstance(record[1][key][0], bytes) and key != 'objectSid':
              value = record[1][key][0].decode('utf-8')
              record[1][key] = [value]
        if self._dn_requested:
          merged_records = {'dn': record[0]}
          merged_records.update(record[1])
          yield merged_records
        else:
          yield record[1]
```
I'll create a pull request, please modify as needed.