### PR TITLE
Fix DEP8 when apparmor is enabled for slapd

### DIFF
--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -47,8 +47,8 @@ override_apparmor() {
 
   # the test suite brings up a test slapd server running
   # off /tmp/<tmpdir>.
-  echo "/tmp/${WORKDIR}/ rw," | sudo tee "$slapd_apparmor_override"
-  echo "/tmp/${WORKDIR}/** rwk," | sudo tee -a "$slapd_apparmor_override"
+  echo "${WORKDIR}/ rw," | sudo tee "$slapd_apparmor_override"
+  echo "${WORKDIR}/** rwk," | sudo tee -a "$slapd_apparmor_override"
   sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
 }
 

--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -13,7 +13,16 @@ else
     ARTIFACTS=${ADT_ARTIFACTS}
 fi
 
+slapd_apparmor_bkp="${WORKDIR}/slapd_profile.bkp"
+slapd_apparmor_override="/etc/apparmor.d/local/usr.sbin.slapd"
+slapd_apparmor="/etc/apparmor.d/usr.sbin.slapd"
+
 cleanup() {
+  if [[ -f "$slapd_apparmor_bkp" ]]; then
+    sudo cp -af "$slapd_apparmor_bkp" "$slapd_apparmor_override"
+    sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
+  fi
+  rm -f "$slapd_apparmor_bkp"
   if [[ -e "$WORKDIR/slapd.pid" ]]; then
      kill -TERM $(cat $WORKDIR/slapd.pid)
   fi
@@ -23,6 +32,28 @@ cleanup() {
 }
 
 trap cleanup 0 INT QUIT ABRT PIPE TERM
+
+apparmor_enabled() {
+  if [ -x /usr/sbin/aa-status ]; then
+    sudo /usr/sbin/aa-status --enabled && apparmor_enabled="0" || apparmor_enabled="1"
+  else
+    apparmor_enabled="1"
+  fi
+  return "$apparmor_enabled"
+}
+
+override_apparmor() {
+  slapd_apparmor_override="/etc/apparmor.d/local/usr.sbin.slapd"
+  slapd_apparmor="/etc/apparmor.d/usr.sbin.slapd"
+
+  # backup existing override
+  cp -af "$slapd_apparmor_override" "$slapd_apparmor_bkp"
+
+  # the test suite brings up a test slapd server running
+  # off /tmp/<tmpdir>.
+  echo "/tmp/** rwk," | sudo tee "$slapd_apparmor_override"
+  sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
+}
 
 setup_slapd() {
     set -e
@@ -101,6 +132,9 @@ check () {
 }
 
 check
+if apparmor_enabled; then
+  override_apparmor
+fi
 setup_slapd
 run_nsscache ldap nssdb
 run_nsscache ldap files

--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -49,6 +49,8 @@ override_apparmor() {
   # off /tmp/<tmpdir>.
   echo "${WORKDIR}/ rw," | sudo tee "$slapd_apparmor_override"
   echo "${WORKDIR}/** rwk," | sudo tee -a "$slapd_apparmor_override"
+  echo "${ARTIFACTS}/ rw," | sudo tee -a "$slapd_apparmor_override"
+  echo "${ARTIFACTS}/** rwk," | sudo tee -a "$slapd_apparmor_override"
   sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
 }
 

--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -19,10 +19,9 @@ slapd_apparmor="/etc/apparmor.d/usr.sbin.slapd"
 
 cleanup() {
   if [[ -f "$slapd_apparmor_bkp" ]]; then
-    sudo cp -af "$slapd_apparmor_bkp" "$slapd_apparmor_override"
+    sudo mv "$slapd_apparmor_bkp" "$slapd_apparmor_override"
     sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
   fi
-  rm -f "$slapd_apparmor_bkp"
   if [[ -e "$WORKDIR/slapd.pid" ]]; then
      kill -TERM $(cat $WORKDIR/slapd.pid)
   fi

--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -43,9 +43,6 @@ apparmor_enabled() {
 }
 
 override_apparmor() {
-  slapd_apparmor_override="/etc/apparmor.d/local/usr.sbin.slapd"
-  slapd_apparmor="/etc/apparmor.d/usr.sbin.slapd"
-
   # backup existing override
   cp -af "$slapd_apparmor_override" "$slapd_apparmor_bkp"
 

--- a/debian/tests/regtest
+++ b/debian/tests/regtest
@@ -47,7 +47,8 @@ override_apparmor() {
 
   # the test suite brings up a test slapd server running
   # off /tmp/<tmpdir>.
-  echo "/tmp/** rwk," | sudo tee "$slapd_apparmor_override"
+  echo "/tmp/${WORKDIR}/ rw," | sudo tee "$slapd_apparmor_override"
+  echo "/tmp/${WORKDIR}/** rwk," | sudo tee -a "$slapd_apparmor_override"
   sudo /usr/sbin/apparmor_parser -r -T -W "$slapd_apparmor"
 }
 


### PR DESCRIPTION
If apparmor is enabled, override the slapd profile before the test.
(LP: #1862369)

We hit this bug in Ubuntu where slapd (the openldap daemon) runs inside an apparmor profile. This profile doesn't allow slapd to run off of files in /tmp, and blocks that, failing the tests.

This isn't a problem in Debian (yet?), so it's not actually fixing anything in debian, but if this change were to be adopted, then this package could become a sync in ubuntu again.
