### PR TITLE
Ensure that only bytes are written to the cache

### DIFF
--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -314,7 +314,7 @@ class FilesSshkeyMapHandler(FilesCache):
           Number of bytes written to the target.
         """
         sshkey_entry = '%s:%s' % (entry.name, entry.sshkey)
-        target.write(sshkey_entry + '\n')
+        target.write(sshkey_entry.encode() + b'\n')
         return len(sshkey_entry) + 1
 
 
@@ -459,7 +459,7 @@ class FilesNetgroupMapHandler(FilesCache):
             netgroup_entry = '%s %s' % (entry.name, entry.entries)
         else:
             netgroup_entry = entry.name
-        target.write(netgroup_entry + '\n')
+        target.write(netgroup_entry.encode() + b'\n')
         return len(netgroup_entry) + 1
 
 
@@ -510,7 +510,7 @@ class FilesAutomountMapHandler(FilesCache):
                                             entry.location)
         else:
             automount_entry = '%s %s' % (entry.key, entry.location)
-        target.write(automount_entry + '\n')
+        target.write(automount_entry.encode() + b'\n')
         return len(automount_entry) + 1
 
     def GetMapLocation(self):

--- a/nss_cache/caches/files_test.py
+++ b/nss_cache/caches/files_test.py
@@ -129,7 +129,7 @@ class TestFilesCache(mox.MoxTestBase):
         cache = files.FilesNetgroupMapHandler(self.config)
         file_mock = self.mox.CreateMock(sys.stdout)
         file_mock.write(
-            'administrators unix_admins noc_monkeys (-,zero_cool,)\n')
+            b'administrators unix_admins noc_monkeys (-,zero_cool,)\n')
 
         map_entry = netgroup.NetgroupMapEntry()
         map_entry.name = 'administrators'
@@ -143,7 +143,7 @@ class TestFilesCache(mox.MoxTestBase):
         """We correctly write a typical entry in /etc/auto.* format."""
         cache = files.FilesAutomountMapHandler(self.config)
         file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write('scratch -tcp,rw,intr,bg fileserver:/scratch\n')
+        file_mock.write(b'scratch -tcp,rw,intr,bg fileserver:/scratch\n')
 
         map_entry = automount.AutomountMapEntry()
         map_entry.key = 'scratch'

--- a/nss_cache/caches/files_test.py
+++ b/nss_cache/caches/files_test.py
@@ -155,7 +155,7 @@ class TestFilesCache(mox.MoxTestBase):
         self.mox.VerifyAll()
 
         file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write('scratch fileserver:/scratch\n')
+        file_mock.write(b'scratch fileserver:/scratch\n')
 
         map_entry = automount.AutomountMapEntry()
         map_entry.key = 'scratch'


### PR DESCRIPTION
Hello,

Following the Python 3 porting efforts, I propose this small fix to be consistent with the other classes of the same file.
This commit convert the strings to bytes before writing them to the cache.

Best regards