### PR TITLE
Check if displayName exists

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -782,7 +782,8 @@ class PasswdUpdateGetter(UpdateGetter):
         pw = passwd.PasswdMapEntry()
 
         if self.conf.get('ad'):
-            pw.gecos = obj['displayName'][0]
+            if 'displayName' in obj:
+                pw.gecos = obj['displayName'][0]
         elif 'gecos' in obj:
             pw.gecos = obj['gecos'][0]
         elif 'cn' in obj:


### PR DESCRIPTION
When we are using `ldap_ad = 1` config, if a user object has not `displayName` property, the map updater fails.

* DisplayName is not an mandatory field in AD and gecos it's only a descritive field en linux

Fix error:
``` 
pw.gecos = obj['displayName'][0]
KeyError: 'displayName'
```