### PR TITLE
Update http source for required changes related to python3

### DIFF
--- a/nss_cache/sources/httpsource.py
+++ b/nss_cache/sources/httpsource.py
@@ -38,6 +38,7 @@ from nss_cache.util import curl
 
 from io import StringIO
 
+
 def RegisterImplementation(registration_callback):
     registration_callback(HttpFilesSource)
 
@@ -268,7 +269,8 @@ class UpdateGetter(object):
         while retry_count < source.conf['retry_max']:
             try:
                 source.log.debug('fetching %s', url)
-                (resp_code, headers, body_bytes) = curl.CurlFetch(url, conn, self.log)
+                (resp_code, headers,
+                 body_bytes) = curl.CurlFetch(url, conn, self.log)
                 self.log.debug('response code: %s', resp_code)
             finally:
                 if resp_code < 400:

--- a/nss_cache/sources/httpsource.py
+++ b/nss_cache/sources/httpsource.py
@@ -24,6 +24,7 @@ import os
 import pycurl
 import time
 from urllib.parse import urljoin
+from io import StringIO
 
 from nss_cache import error
 from nss_cache.maps import automount
@@ -35,8 +36,6 @@ from nss_cache.maps import sshkey
 from nss_cache.sources import source
 from nss_cache.util import file_formats
 from nss_cache.util import curl
-
-from io import StringIO
 
 
 def RegisterImplementation(registration_callback):
@@ -310,6 +309,7 @@ class UpdateGetter(object):
         except IOError:
             self.log.debug('bzip encoding not found')
 
+        # Wrap in a stringIO so that it can be looped on by newlines in the parser
         response = StringIO(body_bytes.decode('utf-8'))
 
         data_map = self.GetMap(cache_info=response)

--- a/nss_cache/sources/httpsource_test.py
+++ b/nss_cache/sources/httpsource_test.py
@@ -273,9 +273,13 @@ class TestShadowUpdateGetter(mox.MoxTestBase):
 
         self.mox.StubOutWithMock(curl, 'CurlFetch')
 
-        curl.CurlFetch('https://TEST_URL', mock_conn, self.updater.log).AndReturn([200,"",BytesIO(b"""usera:x:::::::
+        curl.CurlFetch('https://TEST_URL', mock_conn,
+                       self.updater.log).AndReturn([
+                           200, "",
+                           BytesIO(b"""usera:x:::::::
 userb:x:::::::
-""").getvalue()])
+""").getvalue()
+                       ])
 
         self.mox.ReplayAll()
         config = {}
@@ -294,7 +298,15 @@ userb:x:::::::
 
         self.mox.StubOutWithMock(curl, 'CurlFetch')
 
-        curl.CurlFetch('https://TEST_URL', mock_conn, self.updater.log).AndReturn([200,"",BytesIO(base64.b64decode("QlpoOTFBWSZTWfm+rXYAAAvJgAgQABAyABpAIAAhKm1GMoQAwRSpHIXejGQgz4u5IpwoSHzfVrsA")).getvalue()])
+        curl.CurlFetch(
+            'https://TEST_URL', mock_conn, self.updater.log
+        ).AndReturn([
+            200, "",
+            BytesIO(
+                base64.b64decode(
+                    "QlpoOTFBWSZTWfm+rXYAAAvJgAgQABAyABpAIAAhKm1GMoQAwRSpHIXejGQgz4u5IpwoSHzfVrsA"
+                )).getvalue()
+        ])
 
         self.mox.ReplayAll()
         config = {}

--- a/nss_cache/sources/httpsource_test.py
+++ b/nss_cache/sources/httpsource_test.py
@@ -17,10 +17,12 @@
 
 __author__ = 'blaedd@google.com (David MacKinnon)'
 
+import base64
 import time
 import unittest
 import pycurl
 from mox3 import mox
+from io import BytesIO
 
 from nss_cache import error
 from nss_cache.maps import automount
@@ -32,9 +34,10 @@ from nss_cache.maps import sshkey
 
 from nss_cache.sources import httpsource
 from nss_cache.util import file_formats
+from nss_cache.util import curl
 
 
-class TestHttpSource(unittest.TestCase):
+class TestHttpSource(mox.MoxTestBase):
 
     def setUp(self):
         """Initialize a basic config dict."""
@@ -229,7 +232,7 @@ class TestHttpUpdateGetter(mox.MoxTestBase):
                           since=None)
 
 
-class TestPasswdUpdateGetter(unittest.TestCase):
+class TestPasswdUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestPasswdUpdateGetter, self).setUp()
@@ -245,7 +248,7 @@ class TestPasswdUpdateGetter(unittest.TestCase):
         self.assertTrue(isinstance(self.updater.CreateMap(), passwd.PasswdMap))
 
 
-class TestShadowUpdateGetter(unittest.TestCase):
+class TestShadowUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestShadowUpdateGetter, self).setUp()
@@ -260,8 +263,48 @@ class TestShadowUpdateGetter(unittest.TestCase):
     def testCreateMap(self):
         self.assertTrue(isinstance(self.updater.CreateMap(), shadow.ShadowMap))
 
+    def testShadowGetUpdatesWithContent(self):
+        mock_conn = self.mox.CreateMockAnything()
+        mock_conn.setopt(mox.IgnoreArg(), mox.IgnoreArg()).MultipleTimes()
+        mock_conn.getinfo(pycurl.INFO_FILETIME).AndReturn(-1)
 
-class TestGroupUpdateGetter(unittest.TestCase):
+        self.mox.StubOutWithMock(pycurl, 'Curl')
+        pycurl.Curl().AndReturn(mock_conn)
+
+        self.mox.StubOutWithMock(curl, 'CurlFetch')
+
+        curl.CurlFetch('https://TEST_URL', mock_conn, self.updater.log).AndReturn([200,"",BytesIO(b"""usera:x:::::::
+userb:x:::::::
+""").getvalue()])
+
+        self.mox.ReplayAll()
+        config = {}
+        source = httpsource.HttpFilesSource(config)
+        result = self.updater.GetUpdates(source, 'https://TEST_URL', 1)
+        print(result)
+        self.assertEqual(len(result), 2)
+
+    def testShadowGetUpdatesWithBz2Content(self):
+        mock_conn = self.mox.CreateMockAnything()
+        mock_conn.setopt(mox.IgnoreArg(), mox.IgnoreArg()).MultipleTimes()
+        mock_conn.getinfo(pycurl.INFO_FILETIME).AndReturn(-1)
+
+        self.mox.StubOutWithMock(pycurl, 'Curl')
+        pycurl.Curl().AndReturn(mock_conn)
+
+        self.mox.StubOutWithMock(curl, 'CurlFetch')
+
+        curl.CurlFetch('https://TEST_URL', mock_conn, self.updater.log).AndReturn([200,"",BytesIO(base64.b64decode("QlpoOTFBWSZTWfm+rXYAAAvJgAgQABAyABpAIAAhKm1GMoQAwRSpHIXejGQgz4u5IpwoSHzfVrsA")).getvalue()])
+
+        self.mox.ReplayAll()
+        config = {}
+        source = httpsource.HttpFilesSource(config)
+        result = self.updater.GetUpdates(source, 'https://TEST_URL', 1)
+        print(result)
+        self.assertEqual(len(result), 2)
+
+
+class TestGroupUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestGroupUpdateGetter, self).setUp()
@@ -277,7 +320,7 @@ class TestGroupUpdateGetter(unittest.TestCase):
         self.assertTrue(isinstance(self.updater.CreateMap(), group.GroupMap))
 
 
-class TestNetgroupUpdateGetter(unittest.TestCase):
+class TestNetgroupUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestNetgroupUpdateGetter, self).setUp()
@@ -294,7 +337,7 @@ class TestNetgroupUpdateGetter(unittest.TestCase):
             isinstance(self.updater.CreateMap(), netgroup.NetgroupMap))
 
 
-class TestAutomountUpdateGetter(unittest.TestCase):
+class TestAutomountUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestAutomountUpdateGetter, self).setUp()
@@ -311,7 +354,7 @@ class TestAutomountUpdateGetter(unittest.TestCase):
             isinstance(self.updater.CreateMap(), automount.AutomountMap))
 
 
-class TestSshkeyUpdateGetter(unittest.TestCase):
+class TestSshkeyUpdateGetter(mox.MoxTestBase):
 
     def setUp(self):
         super(TestSshkeyUpdateGetter, self).setUp()

--- a/nss_cache/sources/httpsource_test.py
+++ b/nss_cache/sources/httpsource_test.py
@@ -37,7 +37,7 @@ from nss_cache.util import file_formats
 from nss_cache.util import curl
 
 
-class TestHttpSource(mox.MoxTestBase):
+class TestHttpSource(unittest.TestCase):
 
     def setUp(self):
         """Initialize a basic config dict."""
@@ -232,7 +232,7 @@ class TestHttpUpdateGetter(mox.MoxTestBase):
                           since=None)
 
 
-class TestPasswdUpdateGetter(mox.MoxTestBase):
+class TestPasswdUpdateGetter(unittest.TestCase):
 
     def setUp(self):
         super(TestPasswdUpdateGetter, self).setUp()
@@ -316,7 +316,7 @@ userb:x:::::::
         self.assertEqual(len(result), 2)
 
 
-class TestGroupUpdateGetter(mox.MoxTestBase):
+class TestGroupUpdateGetter(unittest.TestCase):
 
     def setUp(self):
         super(TestGroupUpdateGetter, self).setUp()
@@ -332,7 +332,7 @@ class TestGroupUpdateGetter(mox.MoxTestBase):
         self.assertTrue(isinstance(self.updater.CreateMap(), group.GroupMap))
 
 
-class TestNetgroupUpdateGetter(mox.MoxTestBase):
+class TestNetgroupUpdateGetter(unittest.TestCase):
 
     def setUp(self):
         super(TestNetgroupUpdateGetter, self).setUp()
@@ -349,7 +349,7 @@ class TestNetgroupUpdateGetter(mox.MoxTestBase):
             isinstance(self.updater.CreateMap(), netgroup.NetgroupMap))
 
 
-class TestAutomountUpdateGetter(mox.MoxTestBase):
+class TestAutomountUpdateGetter(unittest.TestCase):
 
     def setUp(self):
         super(TestAutomountUpdateGetter, self).setUp()
@@ -366,7 +366,7 @@ class TestAutomountUpdateGetter(mox.MoxTestBase):
             isinstance(self.updater.CreateMap(), automount.AutomountMap))
 
 
-class TestSshkeyUpdateGetter(mox.MoxTestBase):
+class TestSshkeyUpdateGetter(unittest.TestCase):
 
     def setUp(self):
         super(TestSshkeyUpdateGetter, self).setUp()

--- a/nss_cache/util/curl.py
+++ b/nss_cache/util/curl.py
@@ -42,7 +42,8 @@ def CurlFetch(url, conn=None, logger=None):
         HandleCurlError(e, logger)
         raise error.Error(e)
     resp_code = conn.getinfo(pycurl.RESPONSE_CODE)
-    return (resp_code, conn.headers.getvalue().decode('utf-8'), conn.body.getvalue())
+    return (resp_code, conn.headers.getvalue().decode('utf-8'),
+            conn.body.getvalue())
 
 
 def HandleCurlError(e, logger=None):

--- a/nss_cache/util/curl.py
+++ b/nss_cache/util/curl.py
@@ -19,7 +19,7 @@ __author__ = 'blaedd@google.com (David MacKinnon)'
 
 import logging
 import pycurl
-from io import StringIO
+from io import BytesIO
 
 from nss_cache import error
 
@@ -32,8 +32,8 @@ def CurlFetch(url, conn=None, logger=None):
         conn = pycurl.Curl()
 
     conn.setopt(pycurl.URL, url)
-    conn.body = StringIO()
-    conn.headers = StringIO()
+    conn.body = BytesIO()
+    conn.headers = BytesIO()
     conn.setopt(pycurl.WRITEFUNCTION, conn.body.write)
     conn.setopt(pycurl.HEADERFUNCTION, conn.headers.write)
     try:
@@ -42,7 +42,7 @@ def CurlFetch(url, conn=None, logger=None):
         HandleCurlError(e, logger)
         raise error.Error(e)
     resp_code = conn.getinfo(pycurl.RESPONSE_CODE)
-    return (resp_code, conn.headers.getvalue(), conn.body.getvalue())
+    return (resp_code, conn.headers.getvalue().decode('utf-8'), conn.body.getvalue())
 
 
 def HandleCurlError(e, logger=None):
@@ -63,8 +63,8 @@ def HandleCurlError(e, logger=None):
     if not logger:
         logger = logging
 
-    code = e[0]
-    msg = e[1]
+    code = e.args[0]
+    msg = e.args[1]
 
     # Config errors
     if code in (pycurl.E_UNSUPPORTED_PROTOCOL, pycurl.E_URL_MALFORMAT,

--- a/nsscache.conf.5
+++ b/nsscache.conf.5
@@ -52,7 +52,7 @@ A complete list of configuration options follows.
 Specifies the source to use to retrieve NSS data from.
 
 Valid Options:
-.I ldap, s3
+.I ldap, s3, http
 
 .TP
 .B cache
@@ -294,6 +294,40 @@ array of records in json format. E.g.
 .I [{"Value": {"sshPublicKey": "ssh-rsa ..."}, "Key": "user1"}].
 Valid attributes:
 .I "sshPublicKey"
+
+.SH http SOURCE OPTIONS
+
+These options configure the behaviour of the
+.I http
+source.
+
+.TP
+.B http_passwd_url
+URL for an HTTP endpoint that returns a file containing
+.B passwd
+records in the standard format. E.g.
+.I root:*:0:0:System Administrator:/var/root:/bin/sh
+
+.TP
+.B http_group_url
+URL for an HTTP endpoint that returns a file containing
+.B group
+records in the standard format. E.g.
+.I users:x:100:memberships....
+
+.TP
+.B http_shadow_url
+URL for an HTTP endpoint that returns a file containing
+.B shadow
+records in the standard format. E.g.
+.I root:*:18866:0:99999:7:::
+
+.TP
+.B http_sshkey_url
+URL for an HTTP endpoint that returns a file containing
+.B sshkey
+records in the standard format. E.g.
+.I root:ssh-rsa ...
 
 .SH nssdb CACHE OPTIONS
 


### PR DESCRIPTION
PYCurl in python3 requires that you use a bytesIO interface when interacting with it.

The previous PR for Python3 https://github.com/google/nsscache/issues/89 specifically mentions that not all sources were tested.

This adds a better test case to ensure that the http source parsing logic functions as intended. 