### PR TITLE
Update the CI actions.

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,48 @@
+# This is a single-maintainer project but I want to require reviews before
+# merge, which means that I need a bot to review my own work.
+name: Automatic pull request approvals
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  check_suite:
+    types:
+      - completed
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false && (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize'
+      ) && (
+        github.actor == 'jaqx0r'
+      )
+    permissions:
+      # wait on check
+      checks: read
+      # create review
+      pull-requests: write
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ github.token }}
+          check-regexp: "test.*"
+          wait-interval: 60
+
+      - uses: "actions/github-script@v6"
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.pulls.createReview({
+              event: "APPROVE",
+              owner: context.repo.owner,
+              pull_number: context.payload.pull_request.number,
+              repo: context.repo.repo,
+            })

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,59 @@
+# We "trust" dependabot updates once they pass tests.
+# (this still requires all other checks to pass!)
+
+# This doesn't work on forked repos per the discussion in
+# https://github.com/pascalgn/automerge-action/issues/46 so don't attempt to
+# add people other than dependabot to the if field below.
+name: dependabot-auto-merge
+on:
+  pull_request_target:
+    types:
+      # Dependabot will label the PR
+      - labeled
+      # Dependabot has rebased the PR
+      - synchronize
+
+jobs:
+  enable-automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    permissions:
+      # enable-automerge is a graphql query, not REST, so isn't documented,
+      # except in a mention in
+      # https://github.blog/changelog/2021-02-04-pull-request-auto-merge-is-now-generally-available/
+      # which says "can only be enabled by users with permissino to merge"; the
+      # REST documentation says you need contents: write to perform a merge.
+      # https://github.community/t/what-permission-does-a-github-action-need-to-call-graphql-enablepullrequestautomerge/197708
+      # says this is it
+      contents: write
+    steps:
+      # Enable auto-merge *before* issuing an approval.
+      - uses: alexwilson/enable-github-automerge-action@main
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  wait-on-checks:
+    needs: enable-automerge
+    runs-on: ubuntu-latest
+    permissions:
+      # wait-on-check requires only checks read
+      checks: read
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-regexp: "test.*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+
+  approve:
+    needs: wait-on-checks
+    runs-on: ubuntu-latest
+    permissions:
+      # https://github.com/hmarr/auto-approve-action/issues/183 says
+      # auto-approve-action requires write on pull-requests
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@24ec4c8cc344fe1cdde70ff37e55ace9e848a1d8
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -1,0 +1,47 @@
+name: Comment CI test results on PR
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      # list and download
+      actions: read
+      # post results as comment
+      pull-requests: write
+      # publish creates a check run
+      checks: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-results"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/test-results.zip', Buffer.from(download.data));
+      - id: unpack
+        run: |
+          mkdir -p test-results
+          unzip -d test-results test-results.zip
+          echo "::set-output name=sha::$(cat test-results/sha-number)"
+      - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        with:
+          commit: ${{ steps.unpack.outputs.sha }}
+          check_name: Unit Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/test-results/**/*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,19 @@
 name: CI
 on:
   push:
+    tags:
+      - v*
+    branches:
+      - main
   pull_request:
+
+permissions:
+  # none-all, which doesn't exist, but
+  # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow
+  # implies that the token still gets created.  Elsewhere we learn that any
+  # permission not mentioned here gets turned to `none`.
+  actions: none
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3.1.2
         with:
-          python-version: '3.7'
+          python-version: '^3.x'
           cache: 'pip'
       - name: install dependencies
         run: |
@@ -21,12 +33,18 @@ jobs:
       - name: Test
         run: python setup.py test --addopts "-v --durations=0 --junitxml=test-results/junit.xml --cov=nss_cache"
       - uses: codecov/codecov-action@v3
+        if: always()
       - name: Install
         run: pip install --user .
       - name: slapd Regression Test
         run: |
           sudo apt-get install -y slapd ldap-utils libnss-db db-util
           tests/slapd-regtest
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
       - name: yapf
         run: |
           pip install yapf


### PR DESCRIPTION
auto review my own changes, because i'm a single maintainer and still want to
rely on github review checks

automerge dependabot changes

comment CI test results on the change.