### PR TITLE
Respect uidattr when writing out matching group

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -885,6 +885,8 @@ class GroupUpdateGetter(UpdateGetter):
         if self.conf.get('ad'):
             gr.name = obj['sAMAccountName'][0]
         # hack to map the users as the corresponding group with the same name
+        elif 'uidattr' in self.conf and self.conf['uidattr'] in obj:
+            gr.name = obj[self.conf['uidattr']][0]
         elif 'uid' in obj:
             gr.name = obj['uid'][0]
         else:


### PR DESCRIPTION
The `uidattr` feature was not considered when writing out the matching
group for a particular user. This change adds this missing feature to
the group logic.

Fixed: #150