### PR TITLE
WIP: Updating tests to use unittest.mock instead of mox.

### DIFF
--- a/nss_cache/caches/caches_test.py
+++ b/nss_cache/caches/caches_test.py
@@ -22,7 +22,7 @@ import platform
 import stat
 import tempfile
 import unittest
-from mox3 import mox
+from unittest import mock
 
 from nss_cache import config
 from nss_cache.caches import caches
@@ -42,7 +42,7 @@ class FakeCacheCls(caches.Cache):
         return os.path.join(self.output_dir, self.CACHE_FILENAME + '.test')
 
 
-class TestCls(mox.MoxTestBase):
+class TestCls(unittest.TestCase):
 
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
@@ -77,20 +77,15 @@ class TestCls(mox.MoxTestBase):
         os.unlink(cache.GetCacheFilename())
 
 
-class TestCache(mox.MoxTestBase):
+class TestCache(unittest.TestCase):
 
     def testWriteMap(self):
         cache_map = caches.Cache({}, config.MAP_PASSWORD, None)
-        self.mox.StubOutWithMock(cache_map, '_Commit')
-        self.mox.StubOutWithMock(cache_map, 'Write')
-        self.mox.StubOutWithMock(cache_map, 'Verify')
-        cache_map._Commit()
-        cache_map.Write('writable_map').AndReturn('entries_written')
-        cache_map.Verify('entries_written').AndReturn(True)
-        self.mox.ReplayAll()
-
-        self.assertEqual(0, cache_map.WriteMap('writable_map'))
-
+        with mock.patch.object(cache_map, 'Write') as write, mock.patch.object(cache_map, 'Verify') as verify, mock.patch.object(cache_map, '_Commit') as commit:
+            write.return_value = 'entries_written'
+            verify.return_value = True
+            self.assertEqual(0, cache_map.WriteMap('writable_map'))
+            
 
 if __name__ == '__main__':
     unittest.main()

--- a/nss_cache/caches/files_test.py
+++ b/nss_cache/caches/files_test.py
@@ -22,8 +22,8 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 import sys
-from mox3 import mox
 
 from nss_cache import config
 from nss_cache.maps import automount
@@ -34,7 +34,7 @@ from nss_cache.maps import shadow
 from nss_cache.caches import files
 
 
-class TestFilesCache(mox.MoxTestBase):
+class TestFilesCache(unittest.TestCase):
 
     def setUp(self):
         super(TestFilesCache, self).setUp()
@@ -78,8 +78,7 @@ class TestFilesCache(mox.MoxTestBase):
     def testWritePasswdEntry(self):
         """We correctly write a typical entry in /etc/passwd format."""
         cache = files.FilesPasswdMapHandler(self.config)
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(b'root:x:0:0:Rootsy:/root:/bin/bash\n')
+        file_mock = mock.create_autospec(sys.stdout)
 
         map_entry = passwd.PasswdMapEntry()
         map_entry.name = 'root'
@@ -90,15 +89,13 @@ class TestFilesCache(mox.MoxTestBase):
         map_entry.dir = '/root'
         map_entry.shell = '/bin/bash'
 
-        self.mox.ReplayAll()
-
         cache._WriteData(file_mock, map_entry)
+        file_mock.write.assert_called_with(b'root:x:0:0:Rootsy:/root:/bin/bash\n')
 
     def testWriteGroupEntry(self):
         """We correctly write a typical entry in /etc/group format."""
         cache = files.FilesGroupMapHandler(self.config)
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(b'root:x:0:zero_cool,acid_burn\n')
+        file_mock = mock.create_autospec(sys.stdout)
 
         map_entry = group.GroupMapEntry()
         map_entry.name = 'root'
@@ -106,65 +103,54 @@ class TestFilesCache(mox.MoxTestBase):
         map_entry.gid = 0
         map_entry.members = ['zero_cool', 'acid_burn']
 
-        self.mox.ReplayAll()
-
         cache._WriteData(file_mock, map_entry)
+        file_mock.write.assert_called_with(b'root:x:0:zero_cool,acid_burn\n')
 
     def testWriteShadowEntry(self):
         """We correctly write a typical entry in /etc/shadow format."""
         cache = files.FilesShadowMapHandler(self.config)
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(b'root:$1$zomgmd5support:::::::\n')
+        file_mock = mock.create_autospec(sys.stdout)
 
         map_entry = shadow.ShadowMapEntry()
         map_entry.name = 'root'
         map_entry.passwd = '$1$zomgmd5support'
 
-        self.mox.ReplayAll()
-
         cache._WriteData(file_mock, map_entry)
+        file_mock.write.assert_called_with(b'root:$1$zomgmd5support:::::::\n')
 
     def testWriteNetgroupEntry(self):
         """We correctly write a typical entry in /etc/netgroup format."""
         cache = files.FilesNetgroupMapHandler(self.config)
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(
-            b'administrators unix_admins noc_monkeys (-,zero_cool,)\n')
+        file_mock = mock.create_autospec(sys.stdout)
 
         map_entry = netgroup.NetgroupMapEntry()
         map_entry.name = 'administrators'
         map_entry.entries = 'unix_admins noc_monkeys (-,zero_cool,)'
 
-        self.mox.ReplayAll()
-
         cache._WriteData(file_mock, map_entry)
+        file_mock.write.assert_called_with(b'administrators unix_admins noc_monkeys (-,zero_cool,)\n')
 
     def testWriteAutomountEntry(self):
         """We correctly write a typical entry in /etc/auto.* format."""
         cache = files.FilesAutomountMapHandler(self.config)
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(b'scratch -tcp,rw,intr,bg fileserver:/scratch\n')
+        file_mock = mock.create_autospec(sys.stdout)
 
         map_entry = automount.AutomountMapEntry()
         map_entry.key = 'scratch'
         map_entry.options = '-tcp,rw,intr,bg'
         map_entry.location = 'fileserver:/scratch'
 
-        self.mox.ReplayAll()
         cache._WriteData(file_mock, map_entry)
-        self.mox.VerifyAll()
+        file_mock.write.assert_called_with(b'scratch -tcp,rw,intr,bg fileserver:/scratch\n')
 
-        file_mock = self.mox.CreateMock(sys.stdout)
-        file_mock.write(b'scratch fileserver:/scratch\n')
-
+        file_mock = mock.create_autospec(sys.stdout)
         map_entry = automount.AutomountMapEntry()
         map_entry.key = 'scratch'
         map_entry.options = None
         map_entry.location = 'fileserver:/scratch'
 
-        self.mox.ReplayAll()
-
         cache._WriteData(file_mock, map_entry)
+        file_mock.write.assert_called_with(b'scratch fileserver:/scratch\n')
 
     def testAutomountSetsFilename(self):
         """We set the correct filename based on mountpoint information."""

--- a/nss_cache/util/timestamps_test.py
+++ b/nss_cache/util/timestamps_test.py
@@ -22,12 +22,12 @@ import shutil
 import tempfile
 import time
 import unittest
-from mox3 import mox
+from unittest import mock
 
 from nss_cache.util import timestamps
 
 
-class TestTimestamps(mox.MoxTestBase):
+class TestTimestamps(unittest.TestCase):
 
     def setUp(self):
         super(TestTimestamps, self).setUp()
@@ -64,12 +64,10 @@ class TestTimestamps(mox.MoxTestBase):
         ts_file.close()
 
         now = time.gmtime(1)
-        self.mox.StubOutWithMock(time, 'gmtime')
-        time.gmtime().AndReturn(now)
-        self.mox.ReplayAll()
-
-        ts = timestamps.ReadTimestamp(ts_filename)
-        self.assertEqual(now, ts)
+        with mock.patch('time.gmtime') as gmtime:
+            gmtime.return_value = now
+            ts = timestamps.ReadTimestamp(ts_filename)
+            self.assertEqual(now, ts)  
 
     def testWriteTimestamp(self):
         ts_filename = os.path.join(self.workdir, 'tsw')


### PR DESCRIPTION
Currently this is a rather..brute force approach. While the tests in this PR were fairly straightforward (hopefully!) the leftover tests are ...sometimes challenging.

Two things I'm looking to add in future PRs reduce the complexity here:
 - Some kind of test parameterization (there is a fair amount of code duplication in some tests.)
 - More fakes instead of mocks (e.g. FakeLock instead of mocking out locks.Pidfile() in places.)

Some of the latter tests also have fairly tight coupling; mostly regarding the use of mocking (e.g. to verify function calls were made as expected.) I'm curious how much effort we want to expend to port these 1:1, vs trying to reduce the coupling.

Aiming for an incremental approach though.