### PR TITLE
Pass force_write on FullUpdates

### DIFF
--- a/nss_cache/caches/files.py
+++ b/nss_cache/caches/files.py
@@ -39,6 +39,8 @@ from nss_cache.util import file_formats
 
 
 def LongestLength(l):
+    if len(l) == 0:
+        return 0
     return len(max(l, key=len))
 
 

--- a/nss_cache/command_test.py
+++ b/nss_cache/command_test.py
@@ -220,7 +220,7 @@ class TestUpdateCommand(mox.MoxTestBase):
             config.MAP_PASSWORD].source).AndReturn(source_mock)
 
         cache_mock = self.mox.CreateMock(caches.Cache)
-        cache_mock.WriteMap(map_data=passwd_map).AndReturn(0)
+        cache_mock.WriteMap(map_data=passwd_map, force_write=False).AndReturn(0)
 
         self.mox.StubOutWithMock(cache_factory, 'Create')
         cache_factory.Create(self.conf.options[config.MAP_PASSWORD].cache,
@@ -259,8 +259,8 @@ class TestUpdateCommand(mox.MoxTestBase):
 
         cache_mock = self.mox.CreateMock(caches.Cache)
         cache_mock.GetMapLocation().AndReturn('home')
-        cache_mock.WriteMap(map_data=automount_map).AndReturn(0)
-        cache_mock.WriteMap(map_data=automount_map).AndReturn(0)
+        cache_mock.WriteMap(map_data=automount_map, force_write=False).AndReturn(0)
+        cache_mock.WriteMap(map_data=automount_map, force_write=False).AndReturn(0)
 
         self.mox.StubOutWithMock(cache_factory, 'Create')
         cache_factory.Create(self.conf.options[config.MAP_AUTOMOUNT].cache,

--- a/nss_cache/update/files_updater.py
+++ b/nss_cache/update/files_updater.py
@@ -129,7 +129,7 @@ class FileMapUpdater(updater.Updater):
                 'Source map empty during full update, aborting. '
                 'Use --force-write to override.')
 
-        return_val += cache.WriteMap(map_data=source_map)
+        return_val += cache.WriteMap(map_data=source_map, force_write=force_write)
 
         # We did an update, write our timestamps unless there is an error.
         if return_val == 0:

--- a/nss_cache/update/map_updater.py
+++ b/nss_cache/update/map_updater.py
@@ -143,7 +143,7 @@ class MapUpdater(updater.Updater):
                 'Source map empty during full update, aborting. '
                 'Use --force-write to override.')
 
-        return_val = cache.WriteMap(map_data=new_map)
+        return_val = cache.WriteMap(map_data=new_map, force_write=force_write)
 
         # We did an update, write our timestamps unless there is an error.
         if return_val == 0:

--- a/nss_cache/update/map_updater_test.py
+++ b/nss_cache/update/map_updater_test.py
@@ -63,7 +63,7 @@ class SingleMapUpdaterTest(mox.MoxTestBase):
         password_map.SetModifyTimestamp(new_modify_stamp)
 
         cache_mock = self.mox.CreateMock(files.FilesCache)
-        cache_mock.WriteMap(map_data=password_map).AndReturn(0)
+        cache_mock.WriteMap(map_data=password_map, force_write=False).AndReturn(0)
 
         source_mock = self.mox.CreateMock(source.Source)
         source_mock.GetMap(config.MAP_PASSWORD,


### PR DESCRIPTION
Hi! Thank you for this very useful tool. I suppose, I found a bug.
Steps to reproduce it:
1. No entries in source (LDAP in my case)
2. Full update with force flag (nsscache --config-file=/etc/nsscache.conf update --full --force-write)
3. Even with force-write flag provided it can't update cache because of an empty map

I looked in source code and found that force_flag doesn't get passed into WriteMap  function.