### PR TITLE
ci: Use latest Python now we've stopped using mox.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4.6.1
         with:
-          python-version: '3.10'
           cache: 'pip'
       - name: install dependencies
         run: |


### PR DESCRIPTION
Issue: #156