### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p test-results
           unzip -d test-results test-results.zip
-          echo "::set-output name=sha::$(cat test-results/sha-number)"
+          echo "sha=$(cat test-results/sha-number)" >> "$GITHUB_OUTPUT"
       - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
         with:
           commit: ${{ steps.unpack.outputs.sha }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter