### PR TITLE
Set fallback timestamp to 0 if LDAP object lacks modifyTimestamp

### DIFF
--- a/nss_cache/sources/ldapsource.py
+++ b/nss_cache/sources/ldapsource.py
@@ -743,7 +743,7 @@ class UpdateGetter(object):
                 try:
                     obj_ts = self.FromLdapToTimestamp(obj["modifyTimestamp"][0])
                 except KeyError:
-                    obj_ts = self.FromLdapToTimestamp(obj["modifyTimeStamp"][0])
+                    obj_ts = 0
 
             if max_ts is None or obj_ts > max_ts:
                 max_ts = obj_ts


### PR DESCRIPTION
in ldapsources, the `except` block should not repeat the KeyError.

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nss_cache/sources/ldapsource.py", line 745, in GetUpdates
    obj_ts = self.FromLdapToTimestamp(obj["modifyTimestamp"][0])
                                      ~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'modifyTimestamp'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/sbin/nsscache", line 32, in <module>
    return_value = nsscache_app.Run(sys.argv[1:], os.environ)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/app.py", line 258, in Run
    retval = command_callable().Run(conf=conf, args=args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/command.py", line 246, in Run
    return self.UpdateMaps(
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/command.py", line 324, in UpdateMaps
    retval = updater.UpdateFromSource(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/update/updater.py", line 291, in UpdateFromSource
    return self.UpdateCacheFromSource(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/update/map_updater.py", line 73, in UpdateCacheFromSource
    source_map = source.GetMap(self.map_name, location=location)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/sources/source.py", line 66, in GetMap
    return self.GetPasswdMap(since)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/sources/ldapsource.py", line 472, in GetPasswdMap
    return PasswdUpdateGetter(self.conf).GetUpdates(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nss_cache/sources/ldapsource.py", line 747, in GetUpdates
    obj_ts = self.FromLdapToTimestamp(obj["modifyTimeStamp"][0])
                                      ~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'modifyTimeStamp'
```